### PR TITLE
Add support for storage.conf,policy.json; fix user config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,62 @@ specify per-container scope with `systemd_unit_scope` in `podman_kube_specs`. By
 default, rootless containers will use `user` and root containers will use
 `system`.
 
+### podman_containers_conf
+
+These are the containers.conf(5) settings, provided as a `dict`.  These settings
+will be provided in a drop-in file in the `containers.conf.d` directory.  If
+running as root (see `podman_run_as_user`), the system settings will be managed,
+otherwise, the user settings will be managed.  See the man page for the
+directory locations.
+
+```yaml
+podman_containers_conf:
+  containers:
+    default_sysctls:
+      - net.ipv4.ping_group_range=0 1000
+      - user.max_ipc_namespaces=125052
+```
+
+### podman_registries_conf
+
+These are the containers-registries.conf(5) settings, provided as a `dict`.
+These settings will be provided in a drop-in file in the `registries.conf.d`
+directory.  If running as root (see `podman_run_as_user`), the system settings
+will be managed, otherwise, the user settings will be managed.  See the man page
+for the directory locations.
+
+```yaml
+podman_registries_conf:
+  aliases:
+    myregistry: registry.example.com
+```
+
+### podman_storage_conf
+
+These are the containers-storage.conf(5) settings, provided as a `dict`.  If
+running as root (see `podman_run_as_user`), the system settings will be managed,
+otherwise, the user settings will be managed.  See the man page for the file
+locations.
+
+```yaml
+podman_storage_conf:
+  storage:
+    runroot: /var/big/partition/container/storage
+```
+
+### podman_policy_json
+
+These are the containers-policy.json(5) settings, provided as a `dict`.  If
+running as root (see `podman_run_as_user`), the system settings will be managed,
+otherwise, the user settings will be managed.  See the man page for the file
+locations.
+
+```yaml
+podman_policy_json:
+  default:
+    type: insecureAcceptAnything
+```
+
 ## Variables Exported by the Role
 
 None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,3 +59,15 @@ podman_containers_conf: {}
 # __podman_registries_conf_system or __podman_registries_conf_user
 # paths, respectively, depending on execution mode selected
 podman_registries_conf: {}
+
+# containers-storage.conf(5) settings
+# If running as root, the configuration file will be created in
+# __podman_storage_conf_system or __podman_storage_conf_user
+# paths, respectively, depending on execution mode selected
+podman_storage_conf: {}
+
+# containers-policy.json(5) settings
+# If running as root, the configuration file will be created in
+# __podman_policy_json_system or __podman_policy_json_user
+# paths, respectively, depending on execution mode selected
+podman_policy_json: {}

--- a/tasks/handle_container_conf_d.yml
+++ b/tasks/handle_container_conf_d.yml
@@ -1,41 +1,23 @@
 ---
+- name: Manage containers conf
+  when: podman_containers_conf | length > 0
+  block:
+    - name: Ensure containers.d exists
+      file:
+        path: "{{ __podman_container_conf_file | dirname }}"
+        state: directory
+        owner: "{{ podman_run_as_user }}"
+        group: "{{ podman_run_as_group if
+          podman_run_as_group is not none else omit }}"
+        mode: "0755"
 
-- name: Ensure containers.d exists - system
-  file:
-    path: "{{ __podman_containers_conf_system|dirname }}"
-    state: "directory"
-    owner: "{{ podman_run_as_user }}"
-    group: "{{ podman_run_as_user }}"
-    mode: "0755"
-  when: podman_run_as_user == "root"
-
-- name: Ensure containers.d exists - user
-  file:
-    path: "{{ __podman_containers_conf_user|dirname }}"
-    state: "directory"
-    owner: "{{ podman_run_as_user }}"
-    group: "{{ podman_run_as_user }}"
-    mode: "0755"
-  when: podman_run_as_user != "root"
-
-- name: Update system container config file
-  template:
-    src: toml.j2
-    dest: "{{ __podman_containers_conf_system }}"
-    owner: "{{ podman_run_as_user }}"
-    group: "{{ podman_run_as_user }}"
-    mode: "0644"
-  vars:
-    __conf: "{{ podman_containers_conf }}"
-  when: podman_run_as_user == "root"
-
-- name: Update non-root user container config file
-  template:
-    src: toml.j2
-    dest: "{{ __podman_containers_conf_user }}"
-    owner: "{{ podman_run_as_user }}"
-    group: "{{ podman_run_as_user }}"
-    mode: "0644"
-  vars:
-    __conf: "{{ podman_containers_conf }}"
-  when: podman_run_as_user != "root"
+    - name: Update container config file
+      template:
+        src: toml.j2
+        dest: "{{ __podman_container_conf_file }}"
+        owner: "{{ podman_run_as_user }}"
+        group: "{{ podman_run_as_group if
+          podman_run_as_group is not none else omit }}"
+        mode: "0644"
+      vars:
+        __conf: "{{ podman_containers_conf }}"

--- a/tasks/handle_policy_json.yml
+++ b/tasks/handle_policy_json.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+- name: Manage policy.json
+  when: podman_policy_json | length > 0
+  block:
+    - name: Ensure policy.json parent dir exists
+      file:
+        path: "{{ __podman_policy_json_file | dirname }}"
+        state: directory
+        owner: "{{ podman_run_as_user }}"
+        group: "{{ podman_run_as_group if
+          podman_run_as_group is not none else omit }}"
+        mode: "0755"
+
+    - name: Stat the policy.json file
+      stat:
+        path: "{{ __podman_policy_json_file }}"
+      register: __podman_policy_stat
+
+    - name: Get the existing policy.json
+      slurp:
+        path: "{{ __podman_policy_json_file }}"
+      register: __podman_policy_slurp
+      when: __podman_policy_stat.stat.exists
+
+    - name: Write new policy.json file
+      copy:
+        content: "{{ podman_policy_json | to_nice_json }}"
+        dest: "{{ __podman_policy_json_file }}"
+        owner: "{{ podman_run_as_user }}"
+        group: "{{ podman_run_as_group if
+          podman_run_as_group is not none else omit }}"
+        mode: "0644"
+      when: __policy_existing != podman_policy_json
+      vars:
+        __policy_existing: "{{ __podman_policy_slurp.content |
+          b64decode | from_json
+          if __podman_policy_stat.stat.exists else {} }}"

--- a/tasks/handle_storage_conf.yml
+++ b/tasks/handle_storage_conf.yml
@@ -1,23 +1,23 @@
 ---
-- name: Manage registries conf
-  when: podman_registries_conf | length > 0
+- name: Manage storage.conf
+  when: podman_storage_conf | length > 0
   block:
-    - name: Ensure registries.d exists
+    - name: Ensure storage.conf parent dir exists
       file:
-        path: "{{ __podman_registries_conf_file | dirname }}"
+        path: "{{ __podman_storage_conf_file | dirname }}"
         state: directory
         owner: "{{ podman_run_as_user }}"
         group: "{{ podman_run_as_group if
           podman_run_as_group is not none else omit }}"
         mode: "0755"
 
-    - name: Update registries config file
+    - name: Update storage config file
       template:
         src: toml.j2
-        dest: "{{ __podman_registries_conf_file }}"
+        dest: "{{ __podman_storage_conf_file }}"
         owner: "{{ podman_run_as_user }}"
         group: "{{ podman_run_as_group if
           podman_run_as_group is not none else omit }}"
         mode: "0644"
       vars:
-        __conf: "{{ podman_registries_conf }}"
+        __conf: "{{ podman_storage_conf }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,12 +23,52 @@
     __podman_version: "{{
       (__podman_version_output.stdout.split())[2] }}"
 
+- name: Get user information
+  getent:
+    database: passwd
+    key: "{{ podman_run_as_user }}"
+    fail_key: false
+
+- name: Fail if user does not exist
+  fail:
+    msg: >
+      The given podman user [{{ podman_run_as_user }}] does not exist -
+      cannot continue
+  when: not ansible_facts['getent_passwd'][podman_run_as_user]
+
+- name: Set config file paths
+  set_fact:
+    __podman_container_conf_file: "{{ __podman_containers_conf_system
+      if podman_run_as_user == 'root' else
+      __podman_user_home_dir ~ '/' ~ __podman_containers_conf_user }}"
+    __podman_registries_conf_file: "{{ __podman_registries_conf_system
+      if podman_run_as_user == 'root' else
+      __podman_user_home_dir ~ '/' ~ __podman_registries_conf_user }}"
+    __podman_storage_conf_file: "{{ __podman_storage_conf_system
+      if podman_run_as_user == 'root' else
+      __podman_user_home_dir ~ '/' ~ __podman_storage_conf_user }}"
+    __podman_policy_json_file: "{{ __podman_policy_json_system
+      if podman_run_as_user == 'root' else
+      __podman_user_home_dir ~ '/' ~ __podman_policy_json_user }}"
+  vars:
+    __podman_user_home_dir: "{{
+      ansible_facts['getent_passwd'][podman_run_as_user][4] }}"
+
 - name: Handle container.conf.d
   include_tasks: handle_container_conf_d.yml
 
 - name: Handle registries.conf.d
   include_tasks: handle_registries_conf_d.yml
 
+- name: Handle storage.conf
+  include_tasks: handle_storage_conf.yml
+
+- name: Handle policy.json
+  include_tasks: handle_policy_json.yml
+
+# This task should ensure that __podman_containers has only
+# parameters valid for containers.podman.podman_container - other
+# parameters should be stripped out into separate vars
 - name: Manage firewall for specified ports
   include_role:
     name: fedora.linux_system_roles.firewall

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -4,11 +4,6 @@
   hosts: all
   vars:
     podman_run_as_user: root
-    podman_containers_conf:
-      containers:
-        annotations:
-          environment: production
-          status: tier2
     test_names_users:
       - [httpd1, user1, 1001]
       - [httpd2, root, 0]
@@ -191,20 +186,6 @@
             podman_kube_specs: "{{ __podman_kube_specs |
               union([__podman_use_kube_file]) | list }}"
 
-        - name: Check root containers.conf.d
-          stat:
-            path: "{{ __podman_containers_conf_system|dirname }}"
-          register: containersd_stat
-          failed_when: not containersd_stat.stat.exists or
-            not containersd_stat.stat.isdir
-
-        - name: Check root registries.conf.d
-          stat:
-            path: "{{ __podman_registries_conf_system|dirname }}"
-          register: registriesd_stat
-          failed_when: not registriesd_stat.stat.exists or
-            not registriesd_stat.stat.isdir
-
         - name: Check if pods are running
           command: podman pod inspect {{ item[0] }} --format {{ __fmt | quote }}
           changed_when: false
@@ -286,21 +267,7 @@
         #   command: podman auto-update --dry-run
         #   changed_when: false
 
-        - name: Manage user containers.d
-          include_role:
-            name: linux-system-roles.podman
-          vars:
-            podman_kube_specs: []
-            podman_run_as_user: user1
-
-        - name: Check users containers.conf.d
-          stat:
-            path: "{{ __podman_containers_conf_user|dirname }}"
-          register: containersd_stat
-          failed_when: not containersd_stat.stat.exists or
-            not containersd_stat.stat.isdir
-
-        - name: Remove containers and units
+        - name: Remove pods and units
           include_role:
             name: linux-system-roles.podman
           vars:
@@ -343,13 +310,6 @@
             __regex: >-
               ^[  ]*podman-kube@.+-{{ item[0] }}[.]yml[.]service[ ]+loaded[
               ]+active
-
-        - name: Check root containers.conf.d should be absent
-          stat:
-            path: "{{ __podman_containers_conf_system|dirname }}"
-          register: containersd_stat
-          failed_when: not containersd_stat.stat.exists or
-            not containersd_stat.stat.isdir
 
       always:
         # have to clean up storage.conf - otherwise, get this message:

--- a/tests/tests_config_files.yml
+++ b/tests/tests_config_files.yml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that the role can manage its config files
+  hosts: all
+  vars:
+    podman_run_as_user: user1
+    podman_containers_conf:
+      containers:
+        annotations:
+          environment: production
+          status: tier2
+    podman_registries_conf:
+      aliases:
+        myregistry: registry.example.com
+    podman_storage_conf:
+      storage:
+        runroot: /tmp
+    podman_policy_json:
+      default:
+        type: insecureAcceptAnything
+  tasks:
+    - name: Create user
+      user:
+        name: user1
+
+    - name: Run the role with user config
+      include_role:
+        name: linux-system-roles.podman
+        public: true
+
+    - name: Check that files exist and are non-null
+      stat:
+        path: "{{ item }}"
+      register: __stat
+      failed_when: not __stat.stat.exists or
+        __stat.stat.size == 0
+      loop:
+        - /home/user1/{{ __podman_containers_conf_user }}
+        - /home/user1/{{ __podman_registries_conf_user }}
+        - /home/user1/{{ __podman_storage_conf_user }}
+        - /home/user1/{{ __podman_policy_json_user }}
+
+    - name: Run the role again with user config
+      include_role:
+        name: linux-system-roles.podman
+        public: true
+
+    - name: Check that files still exist and are non-null
+      stat:
+        path: "{{ item }}"
+      register: __stat
+      failed_when: not __stat.stat.exists or
+        __stat.stat.size == 0
+      loop:
+        - /home/user1/{{ __podman_containers_conf_user }}
+        - /home/user1/{{ __podman_registries_conf_user }}
+        - /home/user1/{{ __podman_storage_conf_user }}
+        - /home/user1/{{ __podman_policy_json_user }}
+
+    - name: Run the role with root config
+      include_role:
+        name: linux-system-roles.podman
+        public: true
+      vars:
+        podman_run_as_user: root
+
+    - name: Check that files exist and are non-null
+      stat:
+        path: "{{ item }}"
+      register: __stat
+      failed_when: not __stat.stat.exists or
+        __stat.stat.size == 0
+      loop:
+        - "{{ __podman_containers_conf_system }}"
+        - "{{ __podman_registries_conf_system }}"
+        - "{{ __podman_storage_conf_system }}"
+        - "{{ __podman_policy_json_system }}"
+
+    - name: Run the role again with user config
+      include_role:
+        name: linux-system-roles.podman
+        public: true
+      vars:
+        podman_run_as_user: root
+
+    - name: Check that files still exist and are non-null
+      stat:
+        path: "{{ item }}"
+      register: __stat
+      failed_when: not __stat.stat.exists or
+        __stat.stat.size == 0
+      loop:
+        - "{{ __podman_containers_conf_system }}"
+        - "{{ __podman_registries_conf_system }}"
+        - "{{ __podman_storage_conf_system }}"
+        - "{{ __podman_policy_json_system }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -31,18 +31,33 @@ __podman_required_facts:
   - distribution_version
   - os_family
 
-__podman_containers_conf_file: 50-systemroles.conf
+__podman_containers_conf_file_name: 50-systemroles.conf
 __podman_containers_conf_system: >-
-  /etc/containers/containers.conf.d/{{ __podman_containers_conf_file }}
+  /etc/containers/containers.conf.d/{{ __podman_containers_conf_file_name }}
 # relative to $HOME
 __podman_containers_conf_user: >-
-  .config/containers/containers.conf.d/{{ __podman_containers_conf_file }}
+  .config/containers/containers.conf.d/{{ __podman_containers_conf_file_name }}
 
-__podman_registries_conf_file: 50-systemroles.conf
+__podman_registries_conf_file_name: 50-systemroles.conf
 __podman_registries_conf_system: >-
-  /etc/containers/registries.conf.d/{{ __podman_registries_conf_file }}
+  /etc/containers/registries.conf.d/{{ __podman_registries_conf_file_name }}
+# relative to $HOME
 __podman_registries_conf_user: >-
-  .config/containers/registries.conf.d/{{ __podman_registries_conf_file }}
+  .config/containers/registries.conf.d/{{ __podman_registries_conf_file_name }}
+
+__podman_storage_conf_file_name: storage.conf
+__podman_storage_conf_system: >-
+  /etc/containers/{{ __podman_storage_conf_file_name }}
+# relative to $HOME
+__podman_storage_conf_user: >-
+  .config/containers/{{ __podman_storage_conf_file_name }}
+
+__podman_policy_json_file_name: policy.json
+__podman_policy_json_system: >-
+  /etc/containers/{{ __podman_policy_json_file_name }}
+# relative to $HOME
+__podman_policy_json_user: >-
+  .config/containers/{{ __podman_policy_json_file_name }}
 
 # location for system kubernetes yaml files
 __podman_system_kube_path: "/etc/containers/ansible-kubernetes.d"


### PR DESCRIPTION
Add support for storage.conf and policy.json
Fix user support - have to get user home dir and add that to paths
Separate config file testing to another test file - too difficult
to figure out which options will interfere with regular container
testing.
