### PR TITLE
remove default directory mode

### DIFF
--- a/tasks/create_update_kube_spec.yml
+++ b/tasks/create_update_kube_spec.yml
@@ -38,6 +38,8 @@
     __defaults: "{{ {'path': item} | combine(__podman_hostdirs_defaults) |
       combine(__owner_group) }}"
   loop: "{{ __podman_volumes }}"
+  become: "{{ __podman_rootless | ternary(true, omit) }}"
+  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
   when:
     - podman_create_host_directories | bool
     - __podman_volumes | d([]) | length > 0

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -3,6 +3,9 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   vars:
+    podman_host_directories:
+      "/tmp/httpd1-create":
+        mode: "0777"
     podman_run_as_user: root
     test_names_users:
       - [httpd1, user1, 1001]
@@ -221,6 +224,10 @@
           failed_when: __return.content != "123"
           loop: [15001, 15002]
 
+        - name: Check host directories
+          command: ls -alrtF /tmp/{{ item[0] }}-create
+          loop: "{{ test_names_users }}"
+
         - name: Run role again to test for idempotency
           include_role:
             name: linux-system-roles.podman
@@ -329,3 +336,8 @@
           loop: [httpd1, httpd2, httpd3]
           tags:
             - tests::cleanup
+
+        - name: Remove kube file src
+          file:
+            path: "{{ __kube_file_src.path }}"
+            state: absent

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,7 +9,6 @@ __podman_packages: [podman]
 # User can override these in podman_host_directories
 __podman_hostdirs_defaults:
   state: directory
-  mode: "0644"
 
 # defaults applied when adding ports
 __podman_ports_defaults:


### PR DESCRIPTION
Do not set a default mode when creating host directories.  Instead,
the role will use whatever the `file` module uses when mode is not
specified.  In order to set a different default mode, the user will
need to figure out how to set the default for the `file` module.
Users can also use `podman_host_directories` to explicitly set the
mode.
