### PR TITLE
Version 1.0.0 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+Changelog
+=========
+
+[1.0.0] - 2022-11-01
+--------------------
+
+### New Features
+
+- Manage podman containers using the `podman kube play` Kubernetes YAML
+  file interface - `podman_kube_spec` - system and user
+
+- Automatically create host volume directories based on specifying host
+  mounted volumes in the K8s YAML spec
+
+- Use `podman_host_directories` to provide detailed ownership, permissions,
+  SELinux policy, etc. for host directories created by the role
+
+- Use `podman_firewall` to manage firewalld properties of ports specified
+  in `podman_kube_spec`
+
+- Use `podman_selinux_ports` to manage SELinux policy for ports specified
+  in `podman_kube_spec`
+
+- Manage config files using `podman_containers_conf`, `podman_registries_conf`,
+  `podman_storage_conf`, and `podman_policy_json`
+
+### Bug Fixes
+
+- none
+
+### Other Changes
+
+- none


### PR DESCRIPTION
[1.0.0] - 2022-11-01
--------------------

### New Features

- Manage podman containers using the `podman kube play` Kubernetes YAML
  file interface - `podman_kube_spec` - system and user

- Automatically create host volume directories based on specifying host
  mounted volumes in the K8s YAML spec

- Use `podman_host_directories` to provide detailed ownership, permissions,
  SELinux policy, etc. for host directories created by the role

- Use `podman_firewall` to manage firewalld properties of ports specified
  in `podman_kube_spec`

- Use `podman_selinux_ports` to manage SELinux policy for ports specified
  in `podman_kube_spec`

- Manage config files using `podman_containers_conf`, `podman_registries_conf`,
  `podman_storage_conf`, and `podman_policy_json`

### Bug Fixes

- none

### Other Changes

- none

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
