### PR TITLE
add checking for subuid, subgid

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Use this to install the collections:
 ansible-galaxy collection install -vv -r meta/collection-requirements.yml
 ```
 
+### Users, groups, subuid, subgid
+
+Users and groups specified in `podman_run_as_user`, `podman_run_as_group`, and
+specified in a kube spec as `run_as_user` and `run_as_group` have the following
+restrictions:
+* They must be already present on the system - the role will not create the
+  users or groups - the role will exit with an error if a non-existent user or
+  group is specified
+* They must already exist in `/etc/subuid` and `/etc/subgid` - the role will
+  exit with an error if a specified user is not present in `/etc/subuid`, or if
+  a specified group is not in `/etc/subgid`
+
 ## Role Variables
 
 ### podman_kube_specs
@@ -29,11 +41,11 @@ except for the following:
 * `run_as_user` - Use this to specify a per-pod user.  If you do not
   specify this, then the global default `podman_run_as_user` value will be used.
   Otherwise, `root` will be used.  NOTE: The user must already exist - the role
-  will not create.
+  will not create.  The user must be present in `/etc/subuid`.
 * `run_as_group` - Use this to specify a per-pod group.  If you do not
   specify this, then the global default `podman_run_as_group` value will be
   used.  Otherwise, `root` will be used.  NOTE: The group must already exist -
-  the role will not create.
+  the role will not create.  The group must be present in `/etc/subgid`.
 * `systemd_unit_scope` - The scope to use for the systemd unit.  If you do not
   specify this, then the global default `podman_systemd_unit_scope` will be
   used.  Otherwise, the scope will be `system` for root containers, and `user`
@@ -136,13 +148,15 @@ podman_selinux_ports:
 
 This is the name of the user to use for all rootless containers.  You can also
 specify per-container username with `run_as_user` in `podman_kube_specs`.  NOTE:
-  The user must already exist - the role will not create.
+The user must already exist - the role will not create.  The user must be
+present in `/etc/subuid`.
 
 ### podman_run_as_group
 
 This is the name of the group to use for all rootless containers.  You can also
 specify per-container group name with `run_as_group` in `podman_kube_specs`.
-  NOTE: The group must already exist - the role will not create.
+NOTE: The group must already exist - the role will not create.  The group must
+be present in `/etc/subgid`.
 
 ### podman_systemd_unit_scope
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,10 +8,8 @@ galaxy_info:
   min_ansible_version: "2.9"
   platforms:
     - name: Fedora
-      versions:  # change this back to all once we drop fedora 35
-        - 36
-        - 37
-        - 38
+      versions:
+        - all
     - name: EL
       versions:
         - "8"

--- a/tasks/handle_kube_spec.yml
+++ b/tasks/handle_kube_spec.yml
@@ -60,18 +60,8 @@
     __podman_kube_name: "{{ __podman_kube['metadata']['name']
       if not __podman_kube is none else none }}"
 
-- name: Get user information
-  getent:
-    database: passwd
-    key: "{{ __podman_user }}"
-    fail_key: false
-
-- name: Fail if user does not exist
-  fail:
-    msg: >
-      The given podman user [{{ __podman_user }}] does not exist -
-      cannot continue
-  when: not ansible_facts['getent_passwd'][__podman_user]
+- name: Check user and group information
+  include_tasks: handle_user_group.yml
 
 - name: Fail if no kube spec is given
   fail:
@@ -84,16 +74,8 @@
 
 - name: Set per-container variables part 3
   set_fact:
-    __podman_group: |-
-      {%- if 'run_as_group' in __podman_kube_spec_item -%}
-      {{ __podman_kube_spec_item['run_as_group'] }}
-      {%- elif podman_run_as_group is not none -%}
-      {{ podman_run_as_group }}
-      {%- else -%}
-      {{ ansible_facts['getent_passwd'][__podman_user][2] }}
-      {%- endif -%}
     __podman_xdg_runtime_dir: >-
-      /run/user/{{ ansible_facts['getent_passwd'][__podman_user][1] }}
+      /run/user/{{ ansible_facts["getent_passwd"][__podman_user][1] }}
     __podman_user_home_dir: "{{
       ansible_facts['getent_passwd'][__podman_user][4] }}"
     __podman_systemd_scope: "{{ __podman_systemd_unit_scope
@@ -125,8 +107,8 @@
 
 - name: Cleanup containers and services
   include_tasks: cleanup_kube_spec.yml
-  when: __podman_state == 'absent'
+  when: __podman_state == "absent"
 
 - name: Create and update containers and services
   include_tasks: create_update_kube_spec.yml
-  when: __podman_state != 'absent'
+  when: __podman_state != "absent"

--- a/tasks/handle_user_group.yml
+++ b/tasks/handle_user_group.yml
@@ -1,0 +1,74 @@
+- name: Get user information
+  getent:
+    database: passwd
+    key: "{{ __podman_user }}"
+    fail_key: false
+  when: "'getent_passwd' not in ansible_facts or
+    __podman_user not in ansible_facts['getent_passwd']"
+
+- name: Fail if user does not exist
+  fail:
+    msg: >
+      The given podman user [{{ __podman_user }}] does not exist -
+      cannot continue
+  when: not ansible_facts["getent_passwd"][__podman_user]
+
+- name: Set group for podman user
+  set_fact:
+    __podman_group: |-
+      {%- if "run_as_group" in __podman_kube_spec_item -%}
+      {{ __podman_kube_spec_item["run_as_group"] }}
+      {%- elif podman_run_as_group is not none -%}
+      {{ podman_run_as_group }}
+      {%- else -%}
+      {{ ansible_facts["getent_passwd"][__podman_user][2] }}
+      {%- endif -%}
+
+- name: Get group information
+  getent:
+    database: group
+    key: "{{ __podman_group }}"
+    fail_key: false
+  when: "'getent_group' not in ansible_facts or
+    __podman_group not in ansible_facts['getent_group']"
+
+- name: Set group name
+  set_fact:
+    __podman_group_name: "{{ ansible_facts['getent_group'].keys() |
+      list | first }}"
+
+- name: Check if user is in subuid file
+  find:
+    path: /etc
+    pattern: subuid
+    use_regex: true
+    contains: "^{{ __podman_user }}:.*$"
+  register: __podman_uid_line_found
+  when: __podman_user not in ["root", "0"]
+
+- name: Fail if user not in subuid file
+  fail:
+    msg: >
+      The given podman user [{{ __podman_user }}] is not in the
+      /etc/subuid file - cannot continue
+  when:
+    - __podman_user not in ["root", "0"]
+    - not __podman_uid_line_found.matched
+
+- name: Check if group is in subgid file
+  find:
+    path: /etc
+    pattern: subgid
+    use_regex: true
+    contains: "^{{ __podman_group_name }}:.*$"
+  register: __podman_gid_line_found
+  when: __podman_group not in ["root", "0"]
+
+- name: Fail if group not in subgid file
+  fail:
+    msg: >
+      The given podman group [{{ __podman_group_name }}] is not in the
+      /etc/subgid file - cannot continue
+  when:
+    - __podman_group not in ["root", "0"]
+    - not __podman_gid_line_found.matched

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,18 +28,11 @@
     __podman_version: "{{
       (__podman_version_output.stdout.split())[2] }}"
 
-- name: Get user information
-  getent:
-    database: passwd
-    key: "{{ podman_run_as_user }}"
-    fail_key: false
-
-- name: Fail if user does not exist
-  fail:
-    msg: >
-      The given podman user [{{ podman_run_as_user }}] does not exist -
-      cannot continue
-  when: not ansible_facts['getent_passwd'][podman_run_as_user]
+- name: Check user and group information
+  include_tasks: handle_user_group.yml
+  vars:
+    __podman_user: "{{ podman_run_as_user }}"
+    __podman_kube_spec_item: {}
 
 - name: Set config file paths
   set_fact:

--- a/tests/roles/caller/tasks/main.yml
+++ b/tests/roles/caller/tasks/main.yml
@@ -1,8 +1,10 @@
 ---
 # tasks file for caller
 
-- include_role:
+- name: Include test role
+  include_role:
     name: "{{ roletoinclude }}"
 
-- assert:
+- name: Check for override
+  assert:
     that: not __caller_override


### PR DESCRIPTION
Ensure that the specified user is present in `/etc/subuid`.
Ensure that the specified group is present in `/etc/subgid`.
Refactor the user/group checking so that it can be used from
multiple contexts.
Clean up some quoting and ansible-lint issues.
