### PR TITLE
Ease permissions on kube spec dir and files

### DIFF
--- a/tasks/create_update_kube_spec.yml
+++ b/tasks/create_update_kube_spec.yml
@@ -81,7 +81,7 @@
     state: directory
     owner: "{{ __podman_user }}"
     group: "{{ __podman_group }}"
-    mode: "0700"
+    mode: "0755"
   when: not __podman_kube is none
 
 - name: Ensure kubernetes yaml files are present
@@ -90,7 +90,7 @@
     dest: "{{ __podman_kube_file }}"
     owner: "{{ __podman_user }}"
     group: "{{ __podman_group }}"
-    mode: "0600"
+    mode: "0644"
   register: __podman_copy
   when: not __podman_kube is none
 


### PR DESCRIPTION
https://github.com/linux-system-roles/podman/issues/39
Using `0700` and `0600` are too restrictive.  Make the directory
and files world readable.
