### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/get_ansible_managed.j2
+++ b/templates/get_ansible_managed.j2
@@ -1,1 +1,2 @@
 {{ ansible_managed | comment }}
+{{ "system_role:podman" | comment(prefix="", postfix="") }}

--- a/templates/toml.j2
+++ b/templates/toml.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:podman" | comment(prefix="", postfix="") }}
 {% if __conf is defined and __conf is iterable %}
 {% for section in __conf %}
 [{{ section }}]


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:podman
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.