### PR TITLE
ansible-lint - changed_when required even with conditional tasks

### DIFF
--- a/tasks/cleanup_kube_spec.yml
+++ b/tasks/cleanup_kube_spec.yml
@@ -43,6 +43,7 @@
   when:
     - __podman_rootless | bool
     - __podman_container_info.containers | length == 0
+  changed_when: true
 
 - name: Prune images no longer in use
   command: podman image prune -f
@@ -51,3 +52,4 @@
   become: "{{ __podman_rootless | ternary(true, omit) }}"
   become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
   when: __podman_removed is changed  # noqa no-handler
+  changed_when: true

--- a/tasks/create_update_kube_spec.yml
+++ b/tasks/create_update_kube_spec.yml
@@ -10,6 +10,7 @@
   when:
     - __podman_rootless | bool
     - not __podman_user_lingering.stat.exists
+  changed_when: true
 
 - name: Get the host mount volumes
   set_fact:

--- a/tasks/handle_kube_spec.yml
+++ b/tasks/handle_kube_spec.yml
@@ -105,6 +105,7 @@
     {{ __podman_kube_file | quote }}
   register: __podman_service_name
   when: __podman_activate_systemd_unit | bool
+  changed_when: false
 
 - name: Cleanup containers and services
   include_tasks: cleanup_kube_spec.yml

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -134,14 +134,17 @@
         - name: Enable podman copr
           command: dnf copr enable rhcontainerbot/podman-next -y
           when: podman_use_copr | d(false)
+          changed_when: true
 
         - name: Install podman from updates-testing
           command: dnf -y install podman
           when: podman_use_copr | d(false)
+          changed_when: true
 
         - name: Podman version
           command: podman --version
           when: podman_use_copr | d(false)
+          changed_when: false
 
         - name: Create user
           user:


### PR DESCRIPTION
ansible-lint now requires the use of changed_when even with
conditional tasks

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
