### PR TITLE
fix: graphroot required in storage.conf on Fedora 37

### DIFF
--- a/tests/tests_config_files.yml
+++ b/tests/tests_config_files.yml
@@ -15,6 +15,7 @@
     podman_storage_conf:
       storage:
         runroot: /tmp
+        graphroot: /var/lib/containers/storage
     podman_policy_json:
       default:
         type: insecureAcceptAnything


### PR DESCRIPTION
Fedora 37 tests fail with an error that `graphroot` is required.
Fix it by adding `graphroot` for storage conf tests.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
