### PR TITLE
Consistent contributing.md for all roles - allow role specific contributing.md section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+[1.1.5] - 2023-04-27
+--------------------
+
+### Bug Fixes
+
+- fix: graphroot required in storage.conf on Fedora 37
+- fix: Use match instead of in for test for jinja 2.7 support
+
+### Other Changes
+
+- test: use podman pod exists to check if pods absent/stopped
+- test: check generated files for ansible_managed, fingerprint
+- test: ensure the test works with ANSIBLE_GATHERING=explicit
+- ci: Add commitlint GitHub action to ensure conventional commits with feedback
+
 [1.1.4] - 2023-04-13
 --------------------
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,24 @@
+Contributing to the Podman Linux System Role
+=============================================
+
+Where to start
+--------------
+
+The first place to go is [Contribute](https://linux-system-roles.github.io/contribute.html).
+This has all of the common information that all role developers need:
+* Role structure and layout
+* Development tools - How to run tests and checks
+* Ansible recommended practices
+* Basic git and github information
+* How to create git commits and submit pull requests
+
+- **Bugs and needed implementations** are listed on [Github
+  Issues](https://github.com/linux-system-roles/podman/issues). Issues labeled with
+[**help
+wanted**](https://github.com/linux-system-roles/podman/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+are likely to be suitable for new contributors!
+
+- **Code** is managed on
+  [Github](https://github.com/linux-system-roles/podman), using [Pull
+Requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
+


### PR DESCRIPTION
Provide a single, consistent contributing.md for all roles.  This mostly links to
and summarizes https://linux-system-roles.github.io/contribute.html

Allow for a role specific section which typically has information about
role particulars, role debugging tips, etc.

See https://github.com/linux-system-roles/.github/pull/19

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
