### PR TITLE
fix: make role work on ansible-core 2.15

### DIFF
--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -130,6 +130,10 @@
               path: /tmp/httpd3-create
   tasks:
     - name: Run basic tests
+      vars:
+        __podman_use_kube_file:
+          state: started
+          kube_file_src: "{{ __kube_file_src.path }}"
       block:
         - name: Enable podman copr
           command: dnf copr enable rhcontainerbot/podman-next -y
@@ -187,9 +191,6 @@
             name: linux-system-roles.podman
             public: true
           vars:
-            __podman_use_kube_file:
-              state: started
-              kube_file_src: "{{ __kube_file_src.path }}"
             podman_kube_specs: "{{ __podman_kube_specs |
               union([__podman_use_kube_file]) | list }}"
 


### PR DESCRIPTION
I guess ansible-core 2.15 does not export `vars` defined
in a `include_role` keyword in a play to other task sections in
the play.  The fix is to declare the variable in the `vars`
at the `block` level.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
