### PR TITLE
feat: allow not pulling images, continue if pull fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ except for the following:
 * `activate_systemd_unit` - Whether or not to activate the systemd unit when it
   is created.  If you do not specify this, then the global default
   `podman_activate_systemd_unit` will be used, which is `true` by default.
+* `pull_image` - Ensure the image is pulled before use.  If you do not specify
+  this, then the global default `podman_pull_image` will be used, which is
+  `true` by default.
+* `continue_if_pull_fails` - If pulling the image, and the pull fails, do not
+  treat this as a fatal error, and continue with the role.  If you do not
+  specify this, then the global default `podman_continue_if_pull_fails` will be
+  used, which is `false` by default.
 * `kube_file_src` - This is the name of a file on the controller node which will
   be copied to `kube_file` on the managed node.  This is a file in Kubernetes
   YAML format.  Do not specify this if you specify `kube_file_content`.
@@ -273,6 +280,31 @@ This is systemd scope to use by default for all systemd units.  You can also
 specify per-container scope with `systemd_unit_scope` in `podman_kube_specs`. By
 default, rootless containers will use `user` and root containers will use
 `system`.
+
+### podman_activate_systemd_units
+
+Activate each systemd unit as soon as it is created.  The default is `true`. You
+can also do this on a per-unit basis by using `activate_systemd_units` in the
+spec for each unit. For example, if you are deploying several specs, and you
+only want the last one in the list to activate which will trigger the others to
+activate via dependencies, then set `activate_systemd_unit: false` for each one
+except the last one uses `activate_systemd_unit: true`.  *NOTE*: quadlet units
+are implicitly enabled when created - you cannot currently use
+`activate_systemd_unit` to disable those units - you can use
+`activate_systemd_unit` to create units stopped or started.
+
+### podman_pull_image
+
+Ensure that each image mentioned in a kube or quadlet spec is present by pulling
+the image before it is used.  The default is `true`.  Use `false` if the managed
+node already has the correct version, or is not able to pull images.  You can also
+specify this on a per-unit basis with `pull_image`.
+
+### podman_continue_if_pull_fails
+
+If the image pull attempt fails, do not treat this as a fatal error, and continue
+with the role run.  The default is `false` - a pull attempt failure is a fatal
+error.  You can set this on a per-unit basis with `continue_if_pull_fails`.
 
 ### podman_containers_conf
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,3 +93,14 @@ podman_secrets: []
 # then set `activate_systemd_unit: false` for each one
 # except the last one uses `activate_systemd_unit: true`
 podman_activate_systemd_unit: true
+
+# Ensure images used are present
+# Look at the specs, and pull images that are specified there
+# You can also do this on a per-spec basis using pull_images
+podman_pull_image: true
+
+# Continue if the image pull fails
+# If pulling the image fails, do not fail the role - continue
+# running the role.
+# You can do this on a per-spec basis using continue_if_pull_fails
+podman_continue_if_pull_fails: false

--- a/tasks/cleanup_quadlet_spec.yml
+++ b/tasks/cleanup_quadlet_spec.yml
@@ -15,7 +15,7 @@
   when: __podman_service_name | length > 0
   failed_when:
     - __podman_service_status is failed
-    - not __podman_service_status.stdout is search(__service_error)
+    - not __podman_service_status.msg is search(__service_error)
   vars:
     __service_error: Could not find the requested service
 

--- a/tasks/create_update_kube_spec.yml
+++ b/tasks/create_update_kube_spec.yml
@@ -46,6 +46,10 @@
     username: "{{ container_image_user | default(omit) }}"
     password: "{{ container_image_password | default(omit) }}"
   register: __podman_image_updated
+  when: __podman_pull_image | bool
+  failed_when:
+    - __podman_image_updated is failed
+    - not __podman_continue_if_pull_fails
   environment:
     XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
   become: "{{ __podman_rootless | ternary(true, omit) }}"

--- a/tasks/create_update_quadlet_spec.yml
+++ b/tasks/create_update_quadlet_spec.yml
@@ -30,6 +30,10 @@
     username: "{{ container_image_user | default(omit) }}"
     password: "{{ container_image_password | default(omit) }}"
   register: __podman_image_updated
+  when: __podman_pull_image | bool
+  failed_when:
+    - __podman_image_updated is failed
+    - not __podman_continue_if_pull_fails
   environment:
     XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
   become: "{{ __podman_rootless | ternary(true, omit) }}"

--- a/tasks/handle_kube_spec.yml
+++ b/tasks/handle_kube_spec.yml
@@ -28,7 +28,8 @@
       else none }}"
   vars:
     __del_params: "^(kube_file_src|kube_file_content|run_as_user|run_as_group|\
-      systemd_unit_scope|activate_systemd_unit)$"
+      systemd_unit_scope|activate_systemd_unit|pull_image|\
+      continue_if_pull_fails)$"
 
 - name: Set per-container variables part 1
   set_fact:
@@ -47,6 +48,11 @@
       __podman_kube_spec_item['systemd_unit_scope'] |
       d(podman_systemd_unit_scope) }}"
     __podman_state: "{{ __state }}"
+    __podman_pull_image: "{{ __podman_kube_spec_item['pull_image'] |
+      d(podman_pull_image) }}"
+    __podman_continue_if_pull_fails: "{{
+      __podman_kube_spec_item['continue_if_pull_fails'] |
+      d(podman_continue_if_pull_fails) }}"
   vars:
     __state: "{{ ((__podman_kube_spec_item['state'] | d('')) == 'absent') |
       ternary('absent', 'created') }}"

--- a/tasks/handle_quadlet_spec.yml
+++ b/tasks/handle_quadlet_spec.yml
@@ -34,7 +34,25 @@
       else none }}"
   vars:
     __del_params: "^(file_src|file_content|file|run_as_user|run_as_group|\
-      systemd_unit_scope|name|type|state|activate_systemd_unit|template_src)$"
+      systemd_unit_scope|name|type|state|activate_systemd_unit|template_src|\
+      pull_image|continue_if_pull_fails)$"
+
+- name: Set per-container variables part 1
+  set_fact:
+    __podman_user: "{{ __podman_quadlet_spec_item['run_as_user'] |
+      d(podman_run_as_user) }}"
+    __podman_systemd_unit_scope: "{{
+      __podman_quadlet_spec_item['systemd_unit_scope'] |
+      d(podman_systemd_unit_scope) }}"
+    __podman_state: "{{ __state }}"
+    __podman_pull_image: "{{ __podman_quadlet_spec_item['pull_image'] |
+      d(podman_pull_image) }}"
+    __podman_continue_if_pull_fails: "{{
+      __podman_quadlet_spec_item['continue_if_pull_fails'] |
+      d(podman_continue_if_pull_fails) }}"
+  vars:
+    __state: "{{ ((__podman_quadlet_spec_item['state'] | d('')) == 'absent') |
+      ternary('absent', 'created') }}"
 
 - name: Fail if no quadlet spec is given
   fail:
@@ -47,18 +65,7 @@
     - not __podman_quadlet_file_src
     - not __podman_quadlet_str
     - not __podman_quadlet_template_src
-
-- name: Set per-container variables part 1
-  set_fact:
-    __podman_user: "{{ __podman_quadlet_spec_item['run_as_user'] |
-      d(podman_run_as_user) }}"
-    __podman_systemd_unit_scope: "{{
-      __podman_quadlet_spec_item['systemd_unit_scope'] |
-      d(podman_systemd_unit_scope) }}"
-    __podman_state: "{{ __state }}"
-  vars:
-    __state: "{{ ((__podman_quadlet_spec_item['state'] | d('')) == 'absent') |
-      ternary('absent', 'created') }}"
+    - __podman_state != "absent"
 
 - name: Set per-container variables part 2
   set_fact:
@@ -79,8 +86,6 @@
       if __podman_quadlet_file_src else
       __template_base | basename | splitext | last | replace('.', '')
       if __template_base else none }}"
-    __podman_images_found: "{{ [__podman_quadlet_spec['Image']]
-      if 'Image' in __podman_quadlet_spec else none }}"
   vars:
     __file: "{{ __podman_quadlet_spec_item['file']
       if 'file' in __podman_quadlet_spec_item
@@ -111,7 +116,9 @@
       regex_search('(?m)^Image=\"?([^\"]+?)\"?$', '\\1')
       if __podman_quadlet_str
       and __podman_quadlet_type == 'container'
-      else __podman_quadlet_spec['Image'] | d(none) }}"
+      else [__podman_quadlet_spec['Container']['Image']]
+      if __podman_quadlet_spec.get('Container', {}).get('Image')
+      else [] }}"
     __podman_kube_yamls_raw: "{{ __podman_quadlet_str |
       regex_search('(?m)^Yaml=\"?([^\"]+?)\"?$', '\\1')
       if __podman_quadlet_str
@@ -157,7 +164,7 @@
       if 'file' in __podman_quadlet_spec_item
       else none }}"
     __podman_kube: "{{ __podman_kube_content.content | b64decode |
-      from_yaml_all if __podman_kube_content.content is defined
+      from_yaml_all | list if __podman_kube_content.content is defined
       else none }}"
     __images: "{{ __podman_kube | selectattr('spec', 'defined') |
       map(attribute='spec') | selectattr('containers', 'defined') |

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   vars_files:
-    - test_vars.yml
+    - vars/test_vars.yml
   vars:
     podman_host_directories:
       "/tmp/httpd1-create":
@@ -187,6 +187,84 @@
             mode: "0644"
             owner: "{{ item[1] }}"
           loop: "{{ test_names_users }}"
+
+        - name: See if not pulling images fails
+          block:
+            - name: Run role - do not pull images
+              include_role:
+                name: linux-system-roles.podman
+              vars:
+                podman_kube_specs:
+                  - state: created
+                    pull_image: false
+                    activate_systemd_unit: false
+                    kube_file_content: |
+                      apiVersion: v1
+                      kind: Pod
+                      metadata:
+                        labels:
+                          app: test
+                          io.containers.autoupdate: registry
+                        name: nopull
+                      spec:
+                        containers:
+                          - name: nopull
+                            image: {{ test_image }}
+
+            - name: Verify image not pulled
+              assert:
+                that: __podman_image_updated.results[0] is skipped
+
+            - name: Run role - verify continue if pull fails
+              include_role:
+                name: linux-system-roles.podman
+              vars:
+                podman_kube_specs:
+                  - state: created
+                    continue_if_pull_fails: true
+                    activate_systemd_unit: false
+                    kube_file_content: |
+                      apiVersion: v1
+                      kind: Pod
+                      metadata:
+                        labels:
+                          app: test
+                          io.containers.autoupdate: registry
+                        name: bogus
+                      spec:
+                        containers:
+                          - name: bogus
+                            image: this_is_a_bogus_image
+
+          rescue:
+            - name: Verify image not pulled
+              assert:
+                that:
+                  - not __podman_image_updated.results[0] is changed
+                  - not __podman_image_updated.results[0] is skipped
+
+          always:
+            - name: Cleanup
+              include_role:
+                name: linux-system-roles.podman
+              vars:
+                podman_kube_specs:
+                  - state: absent
+                    kube_file_content: |
+                      apiVersion: v1
+                      kind: Pod
+                      metadata:
+                        labels:
+                          app: test
+                          io.containers.autoupdate: registry
+                        name: {{ item }}
+                      spec:
+                        containers:
+                          - name: {{ item }}
+                            image: {{ test_image }}
+              loop:
+                - nopull
+                - bogus
 
         - name: Run role
           include_role:

--- a/tests/tests_config_files.yml
+++ b/tests/tests_config_files.yml
@@ -2,23 +2,6 @@
 ---
 - name: Ensure that the role can manage its config files
   hosts: all
-  vars:
-    podman_run_as_user: user1
-    podman_containers_conf:
-      containers:
-        annotations:
-          environment: production
-          status: tier2
-    podman_registries_conf:
-      aliases:
-        myregistry: registry.example.com
-    podman_storage_conf:
-      storage:
-        runroot: /tmp
-        graphroot: /var/lib/containers/storage
-    podman_policy_json:
-      default:
-        type: insecureAcceptAnything
   tasks:
     - name: Run the tests
       vars:
@@ -34,6 +17,21 @@
           - /home/user1/{{ __podman_registries_conf_user }}
           - /home/user1/{{ __podman_storage_conf_user }}
           - /home/user1/{{ __podman_policy_json_user }}
+        podman_containers_conf:
+          containers:
+            annotations:
+              environment: production
+              status: tier2
+        podman_registries_conf:
+          aliases:
+            myregistry: registry.example.com
+        podman_storage_conf:
+          storage:
+            runroot: /tmp
+            graphroot: /var/lib/containers/storage
+        podman_policy_json:
+          default:
+            type: insecureAcceptAnything
       block:
         - name: Run the role with no config to get private vars
           include_role:
@@ -67,6 +65,8 @@
           include_role:
             name: linux-system-roles.podman
             public: true
+          vars:
+            podman_run_as_user: user1
 
         - name: Check that files exist and are non-null
           stat:
@@ -80,6 +80,8 @@
           include_role:
             name: linux-system-roles.podman
             public: true
+          vars:
+            podman_run_as_user: user1
 
         - name: Check that files still exist and are non-null
           stat:

--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -3,7 +3,7 @@
 - name: Ensure that the role can manage quadlet specs
   hosts: all
   vars_files:
-    - test_vars.yml
+    - vars/test_vars.yml
   vars:
     podman_use_copr: false  # disable copr for CI testing
     podman_fail_if_too_old: false
@@ -40,6 +40,63 @@
             - FOO=/bin/busybox-extras
             - BAZ=test
   tasks:
+    - name: See if not pulling images fails
+      block:
+        - name: Run role - do not pull images
+          include_role:
+            name: linux-system-roles.podman
+          vars:
+            podman_quadlet_specs:
+              - name: nopull
+                type: container
+                state: created
+                pull_image: false
+                activate_systemd_unit: false
+                Install:
+                  WantedBy: default.target
+                Container:
+                  Image: "{{ test_image }}"
+                  ContainerName: nopull
+
+        - name: Verify image not pulled
+          assert:
+            that: __podman_image_updated.results[0] is skipped
+
+        - name: Run role - try to pull bogus image
+          include_role:
+            name: linux-system-roles.podman
+          vars:
+            podman_quadlet_specs:
+              - name: bogus
+                type: container
+                state: created
+                continue_if_pull_fails: true
+                activate_systemd_unit: false
+                Install:
+                  WantedBy: default.target
+                Container:
+                  Image: this_is_a_bogus_image
+                  ContainerName: bogus
+
+        - name: Verify image not pulled and no error
+          assert:
+            that:
+              - not __podman_image_updated.results[0] is changed
+              - not __podman_image_updated.results[0] is skipped
+
+      always:
+        - name: Cleanup
+          include_role:
+            name: linux-system-roles.podman
+          vars:
+            podman_quadlet_specs:
+              - state: absent
+                name: "{{ item }}"
+                type: container
+          loop:
+            - nopull
+            - bogus
+
     - name: Run the role
       include_role:
         name: linux-system-roles.podman

--- a/tests/tests_quadlet_demo.yml
+++ b/tests/tests_quadlet_demo.yml
@@ -3,7 +3,7 @@
 - name: Deploy the quadlet demo app
   hosts: all
   vars_files:
-    - test_vars.yml
+    - vars/test_vars.yml
   vars:
     # NOTE: Currently need to use copr for EL testing for
     # healthcheck, Secret= directive.


### PR DESCRIPTION
Feature: Add `podman_pull_image` - if `false`, do not pull the image before trying
to use it. Add `podman_continue_if_pull_fails` - continue with the role if the image
pull fails.

Reason: The managed node might be isolated and unable to pull images.  The managed
node might be pre-built with images already present.  Users need to have more control
about what happens in these situations.

Result: User can control when/how images are pulled by units.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
