### PR TITLE
fix: support global options in config files

### DIFF
--- a/tasks/handle_quadlet_spec.yml
+++ b/tasks/handle_quadlet_spec.yml
@@ -165,17 +165,17 @@
       else none }}"
     __podman_kube: "{{ __podman_kube_content.content | b64decode |
       from_yaml_all | list if __podman_kube_content.content is defined
-      else none }}"
+      else [] }}"
     __images: "{{ __podman_kube | selectattr('spec', 'defined') |
       map(attribute='spec') | selectattr('containers', 'defined') |
       map(attribute='containers') | flatten | selectattr('image', 'defined') |
       map(attribute='image') | list
-      if __podman_kube }}"
+      if __podman_kube else [] }}"
     __init_images: "{{ __podman_kube | selectattr('spec', 'defined') |
       map(attribute='spec') | selectattr('initContainers', 'defined') |
       map(attribute='initContainers') | flatten |
       selectattr('image', 'defined') | map(attribute='image') | list
-      if __podman_kube }}"
+      if __podman_kube else [] }}"
     __volumes_from_unit_spec: "{{ __podman_quadlet_str |
       regex_findall('(?m)^Volume=\"?([^:]+):.+$') |
       reject('search', '[.]volume$') | list
@@ -190,10 +190,10 @@
       map(attribute='spec') | selectattr('volumes', 'defined') |
       map(attribute='volumes') | flatten | map('dict2items') | list | flatten |
       selectattr('key', 'match', '^hostPath$') | map(attribute='value') |
-      list if __podman_kube }}"
+      list if __podman_kube else [] }}"
     __dir_vols: "{{ __host_paths | selectattr('type', 'defined') |
       selectattr('type', 'match', '^Directory') | list
-      if __podman_kube }}"
+      if __podman_kube else [] }}"
     __notype_vols: "{{ __host_paths | rejectattr('type', 'defined') | list }}"
     __volumes_from_kube_spec: "{{ (__dir_vols + __notype_vols) |
       map(attribute='path') | unique | list

--- a/tasks/handle_registries_conf_d.yml
+++ b/tasks/handle_registries_conf_d.yml
@@ -21,3 +21,6 @@
         mode: "0644"
       vars:
         __conf: "{{ podman_registries_conf }}"
+        __globals:
+          - unqualified-search-registries
+          - credential-helpers

--- a/templates/toml.j2
+++ b/templates/toml.j2
@@ -1,17 +1,26 @@
 {{ ansible_managed | comment }}
 {{ "system_role:podman" | comment(prefix="", postfix="") }}
+{% macro render_option(key, value) %}
+{%   if (value is iterable and ((value is not string) and (value is not mapping))) %}
+{{ key }}={{ value }}
+{%   elif value is mapping and value is not string %}
+{{ key }} = [{%- for k in value %} "{{k}}={{value[k]}}", {%- endfor %}]
+{%   else %}
+{{ key }}="{{ value }}"
+{%   endif %}
+{% endmacro %}
 {% if __conf is defined and __conf is iterable %}
-{% for section in __conf %}
-[{{ section }}]
-{%   for key in __conf[section] %}
-{% if (__conf[section][key] is iterable and ((__conf[section][key] is not string) and (__conf[section][key] is not mapping)))  %}
-{{ key }}={{ __conf[section][key] }}
-{% elif __conf[section][key] is mapping and __conf[section][key] is not string %}
-{% set value_list = [] %}
-{{ key }} = [{%- for k in __conf[section][key] %} "{{k}}={{__conf[section][key][k]}}", {%- endfor %}]
-{% else %}
-{{ key }}="{{ __conf[section][key] }}"
-{% endif %}
+{%   for key in __globals | d([]) %}
+{%     if key in __conf %}
+{{ render_option(key, __conf[key]) -}}
+{%     endif %}
 {%   endfor %}
-{% endfor %}
+{%   for section in __conf %}
+{%     if not section in __globals | d([]) %}
+[{{ section }}]
+{%       for key in __conf[section] %}
+{{ render_option(key, __conf[section][key]) -}}
+{%       endfor %}
+{%     endif %}
+{%   endfor %}
 {% endif %}

--- a/tests/tests_config_files.yml
+++ b/tests/tests_config_files.yml
@@ -25,6 +25,12 @@
         podman_registries_conf:
           aliases:
             myregistry: registry.example.com
+          unqualified-search-registries:
+            - registry-1.example.com
+            - registry-2.example.com
+          credential-helpers:
+            - cred-helper-1
+            - cred-helper-2
         podman_storage_conf:
           storage:
             runroot: /tmp


### PR DESCRIPTION
Cause: The toml code was trying to put global options (options not in a section)
into a section.

Consequence: The podman role gave errors when using global options.

Fix: The toml code will handle global options separately from options which are
placed into sections.

Result: The podman role config files can handle both global options and options
which are in sections.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
