### PR TITLE
ci: systemd is a python role

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -17,8 +17,8 @@ skip_list:
   - var-naming[no-role-prefix]
 exclude_paths:
   - tests/roles/
-  - tests/files/
   - .github/
   - examples/roles/
+  - tests/files/
 mock_roles:
   - linux-system-roles.podman


### PR DESCRIPTION
The systemd role has some python code, so add it to ci

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
