### PR TITLE
refactor: use getsubids to check subuid and subgid

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ restrictions:
 * They must be already present on the system - the role will not create the
   users or groups - the role will exit with an error if a non-existent user or
   group is specified
-* They must already exist in `/etc/subuid` and `/etc/subgid` - the role will
-  exit with an error if a specified user is not present in `/etc/subuid`, or if
-  a specified group is not in `/etc/subgid`
+* They must already exist in `/etc/subuid` and `/etc/subgid`, or are otherwise
+  provided by your identity management system - the role will exit with an error
+  if a specified user is not present in `/etc/subuid`, or if a specified group
+  is not in `/etc/subgid`.  The role uses `getsubids` to check the user and
+  group if available, or checks the files directly if `getsubids` is not
+  available.
 
 ## Role Variables
 

--- a/tasks/handle_user_group.yml
+++ b/tasks/handle_user_group.yml
@@ -38,38 +38,57 @@
     __podman_group_name: "{{ ansible_facts['getent_group'].keys() |
       list | first }}"
 
-- name: Check if user is in subuid file
-  find:
-    path: /etc
-    pattern: subuid
-    use_regex: true
-    contains: "^{{ __podman_user }}:.*$"
-  register: __podman_uid_line_found
-  when: __podman_user not in ["root", "0"]
+- name: See if getsubids exists
+  stat:
+    path: /usr/bin/getsubids
+  register: __podman_stat_getsubids
 
-- name: Fail if user not in subuid file
-  fail:
-    msg: >
-      The given podman user [{{ __podman_user }}] is not in the
-      /etc/subuid file - cannot continue
+# does not work for root
+- name: Use getsubids if available
   when:
     - __podman_user not in ["root", "0"]
-    - not __podman_uid_line_found.matched
+    - __podman_stat_getsubids.stat.exists
+  block:
+    - name: Check user with getsubids
+      command: getsubids {{ __podman_user | quote }}
+      changed_when: false
 
-- name: Check if group is in subgid file
-  find:
-    path: /etc
-    pattern: subgid
-    use_regex: true
-    contains: "^{{ __podman_group_name }}:.*$"
-  register: __podman_gid_line_found
-  when: __podman_group not in ["root", "0"]
+    - name: Check group with getsubids
+      command: getsubids -g {{ __podman_group_name | quote }}
+      changed_when: false
 
-- name: Fail if group not in subgid file
-  fail:
-    msg: >
-      The given podman group [{{ __podman_group_name }}] is not in the
-      /etc/subgid file - cannot continue
+- name: Check subuid, subgid files if no getsubids
   when:
+    - not __podman_stat_getsubids.stat.exists
+    - __podman_user not in ["root", "0"]
     - __podman_group not in ["root", "0"]
-    - not __podman_gid_line_found.matched
+  block:
+    - name: Check if user is in subuid file
+      find:
+        path: /etc
+        pattern: subuid
+        use_regex: true
+        contains: "^{{ __podman_user }}:.*$"
+      register: __podman_uid_line_found
+
+    - name: Fail if user not in subuid file
+      fail:
+        msg: >
+          The given podman user [{{ __podman_user }}] is not in the
+          /etc/subuid file - cannot continue
+      when: not __podman_uid_line_found.matched
+
+    - name: Check if group is in subgid file
+      find:
+        path: /etc
+        pattern: subgid
+        use_regex: true
+        contains: "^{{ __podman_group_name }}:.*$"
+      register: __podman_gid_line_found
+
+    - name: Fail if group not in subgid file
+      fail:
+        msg: >
+          The given podman group [{{ __podman_group_name }}] is not in the
+          /etc/subgid file - cannot continue
+      when: not __podman_gid_line_found.matched

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
+# shadow-utils-subid for getsubids
 __podman_packages:
   - podman
-  - podman-plugins
   - shadow-utils-subid

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,3 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-__podman_packages: [podman, podman-plugins]
+__podman_packages:
+  - podman
+  - podman-plugins
+  - shadow-utils-subid

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,8 @@
 # Put the role's internal variables here that are not distribution specific.
 # You can override these by defining the same variable with a different
 # value in a platform/version specific file in vars/
-__podman_packages: [podman]
+__podman_packages:
+  - podman
 
 # Default values to use when creating host directories for bind mounts
 # User can override these in podman_host_directories


### PR DESCRIPTION
Use the command `getsubids` to check the subuid and subgid if
available.  This allows the use of identity management to provide
the subuid and subgid.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
