### PR TITLE
fix: require the crun package on EL8

### DIFF
--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 __podman_packages:
+  - crun
   - podman
   - podman-plugins
   - shadow-utils-subid

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 __podman_packages:
+  - crun
   - podman
   - podman-plugins
   - shadow-utils-subid


### PR DESCRIPTION
Cause: The podman package on EL 8.8 does not have a dependency on the crun
package.

Consequence: Some quadlet features fail unexpectedly.

Fix: The role will install the crun package explicitly on EL8.

Result: All quadlet features work correctly on EL8.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
