### PR TITLE
ci: support ansible-lint and ansible-test 2.16

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
+---
 # Default state for all rules
 default: true
 

--- a/tests/files/envoy-proxy-configmap.yml
+++ b/tests/files/envoy-proxy-configmap.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,6 +1,5 @@
-# SPDX-License-Identifier: MIT
 ---
-- name: Test role variable override
+- name: Test role include variable override
   hosts: all
   gather_facts: true
   tasks:
@@ -39,9 +38,18 @@
         varfiles: "{{ [facts['distribution']] | product(separators) |
           map('join') | product(versions) | map('join') | list +
           [facts['distribution'], facts['os_family']] }}"
+      register: __varfiles_created
 
     - name: Import role
       import_role:
         name: caller
       vars:
         roletoinclude: linux-system-roles.podman
+
+    - name: Cleanup
+      file:
+        path: "{{ item.dest }}"
+        state: absent
+      loop: "{{ __varfiles_created.results }}"
+      delegate_to: localhost
+      when: inventory_hostname == ansible_play_hosts_all[0]


### PR DESCRIPTION
Fix yamllint issue with markdownlint config

Add cleanup for tests_include_vars_from_parent.yml

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
