### PR TITLE
fix: name of volume quadlet service should be basename-volume.service

### DIFF
--- a/tasks/handle_quadlet_spec.yml
+++ b/tasks/handle_quadlet_spec.yml
@@ -127,7 +127,7 @@
     __podman_service_name: "{{
       __podman_quadlet_name ~ '.service'
       if __podman_quadlet_type in ['container', 'kube']
-      else __podman_quadlet_name ~ '.volume'
+      else __podman_quadlet_name ~ '-volume.service'
       if __podman_quadlet_type in ['volume']
       else none }}"
 

--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -7,7 +7,6 @@
   vars:
     podman_use_copr: false  # disable copr for CI testing
     podman_fail_if_too_old: false
-    podman_activate_systemd_unit: false
     __podman_secrets:
       - name: mysql_container_root_password
         state: present
@@ -25,7 +24,6 @@
         Volume: {}
       - name: quadlet-basic-mysql
         type: container
-        activate_systemd_unit: true
         Install:
           WantedBy: default.target
         Container:

--- a/tests/tests_quadlet_demo.yml
+++ b/tests/tests_quadlet_demo.yml
@@ -11,7 +11,6 @@
     podman_use_copr: false  # disable copr for CI testing
     podman_fail_if_too_old: false
     podman_create_host_directories: true
-    podman_activate_systemd_unit: false
     podman_quadlet_specs:
       - file_src: quadlet-demo.network
       - file_src: quadlet-demo-mysql.volume
@@ -19,7 +18,6 @@
       - file_src: envoy-proxy-configmap.yml
       - template_src: quadlet-demo.yml.j2
       - file_src: quadlet-demo.kube
-        activate_systemd_unit: true
     podman_firewall:
       - port: 8000/tcp
         state: enabled


### PR DESCRIPTION
Cause: The code was using a volume quadlet service name of basename.volume.

Consequence: Attempting to start this service name would give an error such
as "Could not find the requested service NAME.volume: host"

Fix: The volume quadlet service name is changed to basename-volume.service

Result: The volume service can be started with no errors.

See https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#volume-units-volume
for more info.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
