### PR TITLE
test: allow testing to see if secrets are logged

### DIFF
--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -7,11 +7,13 @@
   vars:
     podman_use_copr: false  # disable copr for CI testing
     podman_fail_if_too_old: false
+    __secret_password_env: "{{ lookup('env', 'SYSTEM_ROLES_PODMAN_PASSWORD') }}"
     __podman_secrets:
       - name: mysql_container_root_password
         state: present
         skip_existing: true
-        data: "{{ mysql_container_root_password }}"
+        data: "{{ (__secret_password_env | length > 0) |
+          ternary(__secret_password_env, mysql_container_root_password) }}"
     __podman_quadlet_specs:
       - name: quadlet-basic
         type: network
@@ -133,17 +135,22 @@
           (__podman_quadlet_specs | selectattr('type', 'match', '^network$') |
            list)) | map('combine', __absent) | list }}"
 
-    - name: Set vars for root testing
+    - name: Set secret var for root testing
       set_fact:
         __root_podman_secrets: "{{ __podman_secrets + __json_secret }}"
-        __root_podman_quadlet_specs: "{{ __podman_quadlet_specs +
-          __json_container }}"
         __root_json_data: '{"test": "json"}'
       vars:
         __json_secret:
           - name: json_secret
             state: present
             data: '{"test": "json"}'
+      no_log: true
+
+    - name: Set container vars for root testing
+      set_fact:
+        __root_podman_quadlet_specs: "{{ __podman_quadlet_specs +
+          __json_container }}"
+      vars:
         __json_container:
           - name: json_container
             type: container


### PR DESCRIPTION
The tasks which handle secrets should be marked `no_log: true`.
Data used for secrets should not be logged.  In order to test
this, you can use the environment variable
`SYSTEM_ROLES_PODMAN_PASSWORD` which will use this as the secret
data for the test.  Then, you can search for this string in
the Ansible output/logs.  Any hit means secret data is being
leaked.

```bash
SYSTEM_ROLES_PODMAN_PASSWORD=$(openssl rand -hex 32)
SYSTEM_ROLES_PODMAN_PASSWORD="${SYSTEM_ROLES_PODMAN_PASSWORD}" \
tox -e qemu-ansible-core-2.16 -- --image-name centos-9 --log-level debug \
tests/tests_quadlet_basic.yml > output 2>&1
grep "${SYSTEM_ROLES_PODMAN_PASSWORD}" output
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
