### PR TITLE
fix: Add support for --check flag

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
   when: (__podman_packages | difference(ansible_facts.packages))
 
 - name: Get podman version
+  check_mode: false
   command: podman --version
   changed_when: false
   register: __podman_version_output


### PR DESCRIPTION
Fix: https://github.com/linux-system-roles/podman/issues/133

# Enhancement:

Add support for `ansible-playbook`'s `--check` flag

# Reason:

We can _dry-run_ our playbooks when needed.

# Result:

The run doesn't crash as described in #133 