### PR TITLE
fix: use correct user for cancel linger file name

### DIFF
--- a/tasks/cancel_linger.yml
+++ b/tasks/cancel_linger.yml
@@ -59,4 +59,4 @@
     - __podman_linger_secrets.stdout == ""
   changed_when: true
   args:
-    removes: /var/lib/systemd/linger/{{ __podman_user }}
+    removes: /var/lib/systemd/linger/{{ __podman_linger_user }}

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -409,6 +409,13 @@
               ^[  ]*podman-kube@.+-{{ item[0] }}[.]yml[.]service[ ]+loaded[
               ]+active
 
+        - name: Ensure no linger
+          stat:
+            path: /var/lib/systemd/linger/{{ item[1] }}
+          loop: "{{ test_names_users }}"
+          register: __stat
+          failed_when: __stat.stat.exists
+
       rescue:
         - name: Dump journal
           command: journalctl -ex


### PR DESCRIPTION
Cause: When processing a list of kube or quadlet items, the
code was using the user id associated with the list, not the
item, to specify the linger filename.

Consequence: The linger file does not exist, so the code
does not cancel linger for the actual user.

Fix: Use the correct username to construct the linger filename.

Result: Lingering is cancelled for the correct users.

QE: The test is now in tests_basic.yml

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
