### PR TITLE
test: do not check for root linger

### DIFF
--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -412,6 +412,7 @@
         - name: Ensure no linger
           stat:
             path: /var/lib/systemd/linger/{{ item[1] }}
+          when: item[1] != "root"
           loop: "{{ test_names_users }}"
           register: __stat
           failed_when: __stat.stat.exists


### PR DESCRIPTION
Do not check if there is a linger file for root.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
