### PR TITLE
chore: use none in jinja code, not null

### DIFF
--- a/tasks/handle_user_group.yml
+++ b/tasks/handle_user_group.yml
@@ -104,12 +104,12 @@
           (__podman_register_subuids.content | b64decode).split('\n') | list |
           select('match', '^' ~ __podman_user ~ ':') | list }}"
         __subuid_data: "{{ __subuid_match_line[0].split(':') | list
-          if __subuid_match_line else null }}"
+          if __subuid_match_line else none }}"
         __subgid_match_line: "{{
           (__podman_register_subgids.content | b64decode).split('\n') | list |
           select('match', '^' ~ __podman_group_name ~ ':') | list }}"
         __subgid_data: "{{ __subgid_match_line[0].split(':') | list
-          if __subgid_match_line else null }}"
+          if __subgid_match_line else none }}"
 
     - name: Fail if user not in subuid file
       fail:


### PR DESCRIPTION
Must use `none` in Jinja code, not `null`, which is used in YAML.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
