### PR TITLE
feat: Handle reboot for transactional update systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,16 @@ Boolean - default is `false` - by default, the role will not prune unused images
 when removing quadlets and other resources.  Set this to `true` to tell the role
 to remove unused images when cleaning up.
 
+### podman_transactional_update_reboot_ok
+
+This variable is applicable only for transactional update systems.
+If a transactional update requires a reboot, the role will proceed with the
+reboot if `podman_transactional_update_reboot_ok` is set to `true`. If set
+to `false`, the role will notify the user that a reboot is required, allowing
+for custom handling of the reboot requirement. If this variable is not set,
+the role will fail to ensure the reboot requirement is not overlooked.
+For non-transactional update systems, this variable is ignored.
+
 ## Variables Exported by the Role
 
 ### podman_version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -139,3 +139,6 @@ podman_validate_certs: null
 # Prune images when removing quadlets/kube specs -
 # this will remove all unused/unreferenced images
 podman_prune_images: false
+
+# var to manage reboots for transactional update systems
+podman_transactional_update_reboot_ok: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,30 @@
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   become: true
   when: (__podman_packages | difference(ansible_facts.packages))
+  register: podman_package_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - __podman_is_transactional | d(false)
+    - podman_package_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: Rebooting the system to apply transactional update changes.
+      when: podman_transactional_update_reboot_ok | bool
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          Reboot is required but not allowed. Please set
+          'podman_transactional_update_reboot_ok' to proceed.
+      when:
+        - podman_transactional_update_reboot_ok is none
 
 - name: Get podman version
   check_mode: false

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -18,6 +18,18 @@
       set_fact:
         __podman_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __podman_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __podman_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:


### PR DESCRIPTION
Enhancement: - Added a block to identify and handle reboots for transactional update systems on package changes. Update README.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when a package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
