### PR TITLE
test: skip quadlet tests on non-x86_64

### DIFF
--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -48,6 +48,17 @@
             - FOO=/bin/busybox-extras
             - BAZ=test
   tasks:
+    - name: Test is only supported on x86_64
+      debug:
+        msg: >
+          This test is only supported on x86_64 because the test images used are only
+          available on that platform.
+      when: ansible_facts["architecture"] != "x86_64"
+
+    - name: End test
+      meta: end_play
+      when: ansible_facts["architecture"] != "x86_64"
+
     - name: Run test
       block:
         - name: See if not pulling images fails

--- a/tests/tests_quadlet_demo.yml
+++ b/tests/tests_quadlet_demo.yml
@@ -2,6 +2,7 @@
 ---
 - name: Deploy the quadlet demo app
   hosts: all
+  gather_facts: true
   vars_files:
     - vars/test_vars.yml
   vars:
@@ -28,6 +29,17 @@
       "/tmp/quadlet_demo":
         mode: "0777"
   tasks:
+    - name: Test is only supported on x86_64
+      debug:
+        msg: >
+          This test is only supported on x86_64 because the test images used are only
+          available on that platform.
+      when: ansible_facts["architecture"] != "x86_64"
+
+    - name: End test
+      meta: end_play
+      when: ansible_facts["architecture"] != "x86_64"
+
     - name: Run tests
       block:
         - name: Generate certificates


### PR DESCRIPTION
The images we currently use for quadlet testing are only available
on x86_64

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
