### PR TITLE
fix: Cannot remove volumes from kube yaml - need to convert yaml to list

### DIFF
--- a/tasks/parse_quadlet_file.yml
+++ b/tasks/parse_quadlet_file.yml
@@ -45,7 +45,7 @@
 - name: Parse quadlet yaml file
   set_fact:
     __podman_quadlet_parsed: "{{ __podman_quadlet_raw.content | b64decode |
-      from_yaml_all }}"
+      from_yaml_all | list }}"
   when:
     - __podman_service_name | length == 0
     - __podman_quadlet_file.endswith(".yml") or


### PR DESCRIPTION
Cause: __podman_quadlet_parsed was not converted to a list.

Consequence: On older versions of Ansible, the volumes from the kube yaml
were not removed when removing quadlets.

Fix: Convert __podman_quadlet_parsed to a list after parsing.

Result: Older versions of Ansible can remove volumes specified
in kube yaml files.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
