### PR TITLE
fix: ignore pod not found errors when removing kube specs

### DIFF
--- a/tasks/cleanup_kube_spec.yml
+++ b/tasks/cleanup_kube_spec.yml
@@ -30,6 +30,11 @@
     path: "{{ __podman_kube_file }}"
   register: __podman_kube_file_stat
 
+# NOTE: removing kube specs is not idempotent and will give an error on
+# RHEL 8.8 and 9.2 - seems ok on other platforms - this was fixed in the
+# module but is not released yet (as of 20241024)
+# https://github.com/containers/ansible-podman-collections/pull/863/files#diff-6672fb7f52e2bec3450c2dd7ed9a4385accd9bab8429ea6eecf4d56447f5a1b8R304
+# remove this hack when the fix is available
 - name: Remove pod/containers
   containers.podman.podman_play: "{{ __podman_kube_spec |
     combine({'kube_file': __podman_kube_file}) }}"
@@ -38,9 +43,17 @@
   become: "{{ __podman_rootless | ternary(true, omit) }}"
   become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
   register: __podman_removed
+  failed_when:
+    - __podman_removed is failed
+    - not __podman_removed.msg is search(__err_msg)
+    - not __is_affected_platform
   when:
     - not __podman_rootless or __podman_xdg_stat.stat.exists
     - __podman_kube_file_stat.stat.exists
+  vars:
+    __err_msg: Failed to delete .* with {{ __podman_kube_file }}
+    __is_affected_platform: "{{ ansible_facts['distribution'] == 'RedHat' and
+      ansible_facts['distribution_version'] in ['8.8', '9.2'] }}"
 
 - name: Remove kubernetes yaml file
   file:


### PR DESCRIPTION
Cause: The module uses the `podman kube play --done` command to remove
the pod specified by the kube spec, but does not check if the pod has
already been removed.  That is, it is not idempotent.  The command
gives an error if the pod is not found.  This only happens with
podman 4.4.1 on EL8.8 and EL9.2.

Consequence: The podman role gives an error that the pod specified
by the kube spec cannot be found when removing.

Fix: The role ignores the 'pod not found' error when removing
a kube spec.

Result: The role does not give an error when removing a kube
spec.

NOTE: This has been fixed in the containers.podman.podman_play
module upstream but has not yet been released.
https://github.com/containers/ansible-podman-collections/pull/863/files#diff-6672fb7f52e2bec3450c2dd7ed9a4385accd9bab8429ea6eecf4d56447f5a1b8R304

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
