### PR TITLE
fix: make role work on el 8.8 and el 9.2 and podman version less than 4.7.0

### DIFF
--- a/tasks/cancel_linger.yml
+++ b/tasks/cancel_linger.yml
@@ -63,7 +63,7 @@
     removes: /var/lib/systemd/linger/{{ __podman_linger_user }}
 
 - name: Wait for user session to exit closing state  # noqa no-handler
-  command: loginctl show-user -P State {{ __podman_linger_user | quote }}
+  command: loginctl show-user --value -p State {{ __podman_linger_user | quote }}
   register: __user_state
   changed_when: false
   until: __user_state.stdout != "closing"
@@ -82,7 +82,7 @@
         state: stopped
 
     - name: Wait for user session to exit closing state
-      command: loginctl show-user -P State {{ __podman_linger_user | quote }}
+      command: loginctl show-user --value -p State {{ __podman_linger_user | quote }}
       changed_when: false
       register: __user_state
       until: __user_state.stderr is match(__pat) or

--- a/tests/templates/quadlet-basic.network.j2
+++ b/tests/templates/quadlet-basic.network.j2
@@ -2,4 +2,6 @@
 Subnet=192.168.29.0/24
 Gateway=192.168.29.1
 Label=app=wordpress
+{% if podman_version is version("4.7.0", ">=") %}
 NetworkName=quadlet-basic-name
+{% endif %}

--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -19,15 +19,15 @@
         state: present
         data: "{{ __json_secret_data | string }}"
     __podman_quadlet_specs:
-      - file_src: files/quadlet-basic.network
+      - template_src: templates/quadlet-basic.network.j2
         state: started
       - name: quadlet-basic-unused-network
         type: network
         Network: {}
       - name: quadlet-basic-mysql
         type: volume
-        Volume:
-          VolumeName: quadlet-basic-mysql-name
+        Volume: "{{ {} if podman_version is version('4.7.0', '<')
+          else {'VolumeName': 'quadlet-basic-mysql-name'} }}"
       - name: quadlet-basic-unused-volume
         type: volume
         Volume: {}


### PR DESCRIPTION
Cause: Role was using podman and loginctl features not supported on el 8.8/9.2
and podman versions less than 4.7.0.  NetworkName and VolumeName not supported
until podman 4.7.0.  loginctl -P not supported in el 8.8/9.2.

Consequence: The role would give failures when managing el 8.8/9.2 machines.

Fix: Do not test with NetworkName and VolumeName when podman version is less
than 4.7.0.  Use loginctl --value -p instead of -P which will work on all
versions.

Result: The role can manage el 8.8/9.2 machines.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
