### PR TITLE
fix: get user information for secrets

### DIFF
--- a/tasks/handle_secret.yml
+++ b/tasks/handle_secret.yml
@@ -5,6 +5,12 @@
     __podman_user: "{{ __podman_secret_item['run_as_user'] |
       d(podman_run_as_user) }}"
 
+- name: Check user and group information
+  include_tasks: handle_user_group.yml
+  vars:
+    __podman_spec_item: "{{ __podman_secret_item }}"
+    __podman_check_subids: false
+
 - name: Set variables part 2
   set_fact:
     __podman_rootless: "{{ __podman_user != 'root' }}"

--- a/tasks/handle_user_group.yml
+++ b/tasks/handle_user_group.yml
@@ -14,6 +14,10 @@
       cannot continue
   when: not ansible_facts["getent_passwd"][__podman_user]
 
+- name: Debug
+  debug:
+    msg: item {{ __podman_spec_item | to_nice_json }}
+
 - name: Set group for podman user
   set_fact:
     __podman_group: |-
@@ -26,88 +30,91 @@
       {{ ansible_facts["getent_passwd"][__podman_user][2] }}
       {%- endif -%}
 
-- name: See if getsubids exists
-  stat:
-    path: /usr/bin/getsubids
-  register: __podman_stat_getsubids
-
-# does not work for root
-- name: Use getsubids if available
-  when:
-    - __podman_user not in ["root", "0"]
-    - __podman_stat_getsubids.stat.exists
+- name: Check subids
+  when: __podman_check_subids | d(true)
   block:
-    - name: Check with getsubids for user subuids
-      command: getsubids {{ __podman_user | quote }}
-      changed_when: false
-      register: __podman_register_subuids
+    - name: See if getsubids exists
+      stat:
+        path: /usr/bin/getsubids
+      register: __podman_stat_getsubids
 
-    - name: Check with getsubids for user subgids
-      command: getsubids -g {{ __podman_user | quote }}
-      changed_when: false
-      register: __podman_register_subgids
+    # does not work for root
+    - name: Use getsubids if available
+      when:
+        - __podman_user not in ["root", "0"]
+        - __podman_stat_getsubids.stat.exists
+      block:
+        - name: Check with getsubids for user subuids
+          command: getsubids {{ __podman_user | quote }}
+          changed_when: false
+          register: __podman_register_subuids
 
-    - name: Set user subuid and subgid info
-      set_fact:
-        podman_subuid_info: "{{ podman_subuid_info | d({}) |
-          combine({__podman_user:
-            {'start': __subuid_data[2] | int, 'range': __subuid_data[3] | int}})
-          if __subuid_data | length > 0 else podman_subuid_info | d({}) }}"
-        podman_subgid_info: "{{ podman_subgid_info | d({}) |
-          combine({__podman_user:
-            {'start': __subgid_data[2] | int, 'range': __subgid_data[3] | int}})
-          if __subgid_data | length > 0 else podman_subgid_info | d({}) }}"
-      vars:
-        __subuid_data: "{{ __podman_register_subuids.stdout.split() | list }}"
-        __subgid_data: "{{ __podman_register_subgids.stdout.split() | list }}"
+        - name: Check with getsubids for user subgids
+          command: getsubids -g {{ __podman_user | quote }}
+          changed_when: false
+          register: __podman_register_subgids
 
-- name: Check subuid, subgid files if no getsubids
-  when:
-    - not __podman_stat_getsubids.stat.exists
-    - __podman_user not in ["root", "0"]
-  block:
-    - name: Get subuid file
-      slurp:
-        path: /etc/subuid
-      register: __podman_register_subuids
+        - name: Set user subuid and subgid info
+          set_fact:
+            podman_subuid_info: "{{ podman_subuid_info | d({}) |
+              combine({__podman_user:
+                {'start': __subuid_data[2] | int, 'range': __subuid_data[3] | int}})
+              if __subuid_data | length > 0 else podman_subuid_info | d({}) }}"
+            podman_subgid_info: "{{ podman_subgid_info | d({}) |
+              combine({__podman_user:
+                {'start': __subgid_data[2] | int, 'range': __subgid_data[3] | int}})
+              if __subgid_data | length > 0 else podman_subgid_info | d({}) }}"
+          vars:
+            __subuid_data: "{{ __podman_register_subuids.stdout.split() | list }}"
+            __subgid_data: "{{ __podman_register_subgids.stdout.split() | list }}"
 
-    - name: Get subgid file
-      slurp:
-        path: /etc/subgid
-      register: __podman_register_subgids
+    - name: Check subuid, subgid files if no getsubids
+      when:
+        - not __podman_stat_getsubids.stat.exists
+        - __podman_user not in ["root", "0"]
+      block:
+        - name: Get subuid file
+          slurp:
+            path: /etc/subuid
+          register: __podman_register_subuids
 
-    - name: Set user subuid and subgid info
-      set_fact:
-        podman_subuid_info: "{{ podman_subuid_info | d({}) |
-          combine({__podman_user:
-            {'start': __subuid_data[1] | int, 'range': __subuid_data[2] | int}})
-          if __subuid_data else podman_subuid_info | d({}) }}"
-        podman_subgid_info: "{{ podman_subgid_info | d({}) |
-          combine({__podman_user:
-            {'start': __subgid_data[1] | int, 'range': __subgid_data[2] | int}})
-          if __subgid_data else podman_subgid_info | d({}) }}"
-      vars:
-        __subuid_match_line: "{{
-          (__podman_register_subuids.content | b64decode).split('\n') | list |
-          select('match', '^' ~ __podman_user ~ ':') | list }}"
-        __subuid_data: "{{ __subuid_match_line[0].split(':') | list
-          if __subuid_match_line else none }}"
-        __subgid_match_line: "{{
-          (__podman_register_subgids.content | b64decode).split('\n') | list |
-          select('match', '^' ~ __podman_user ~ ':') | list }}"
-        __subgid_data: "{{ __subgid_match_line[0].split(':') | list
-          if __subgid_match_line else none }}"
+        - name: Get subgid file
+          slurp:
+            path: /etc/subgid
+          register: __podman_register_subgids
 
-    - name: Fail if user not in subuid file
-      fail:
-        msg: >
-          The given podman user [{{ __podman_user }}] is not in the
-          /etc/subuid file - cannot continue
-      when: not __podman_user in podman_subuid_info
+        - name: Set user subuid and subgid info
+          set_fact:
+            podman_subuid_info: "{{ podman_subuid_info | d({}) |
+              combine({__podman_user:
+                {'start': __subuid_data[1] | int, 'range': __subuid_data[2] | int}})
+              if __subuid_data else podman_subuid_info | d({}) }}"
+            podman_subgid_info: "{{ podman_subgid_info | d({}) |
+              combine({__podman_user:
+                {'start': __subgid_data[1] | int, 'range': __subgid_data[2] | int}})
+              if __subgid_data else podman_subgid_info | d({}) }}"
+          vars:
+            __subuid_match_line: "{{
+              (__podman_register_subuids.content | b64decode).split('\n') | list |
+              select('match', '^' ~ __podman_user ~ ':') | list }}"
+            __subuid_data: "{{ __subuid_match_line[0].split(':') | list
+              if __subuid_match_line else none }}"
+            __subgid_match_line: "{{
+              (__podman_register_subgids.content | b64decode).split('\n') | list |
+              select('match', '^' ~ __podman_user ~ ':') | list }}"
+            __subgid_data: "{{ __subgid_match_line[0].split(':') | list
+              if __subgid_match_line else none }}"
 
-    - name: Fail if user not in subgid file
-      fail:
-        msg: >
-          The given podman user [{{ __podman_user }}] is not in the
-          /etc/subgid file - cannot continue
-      when: not __podman_user in podman_subgid_info
+        - name: Fail if user not in subuid file
+          fail:
+            msg: >
+              The given podman user [{{ __podman_user }}] is not in the
+              /etc/subuid file - cannot continue
+          when: not __podman_user in podman_subuid_info
+
+        - name: Fail if user not in subgid file
+          fail:
+            msg: >
+              The given podman user [{{ __podman_user }}] is not in the
+              /etc/subgid file - cannot continue
+          when: not __podman_user in podman_subgid_info

--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -189,10 +189,13 @@
           include_role:
             name: linux-system-roles.podman
           vars:
-            podman_run_as_user: user_quadlet_basic
-            podman_secrets: "{{ __podman_secrets }}"
-            podman_quadlet_specs: "{{ __podman_quadlet_specs }}"
+            podman_quadlet_specs: "{{ __podman_quadlet_specs |
+              map('combine', __run_as_user) | list }}"
             podman_pull_retry: true
+            podman_secrets: "{{ __podman_secrets |
+              map('combine', __run_as_user) | list }}"
+            __run_as_user:
+              run_as_user: user_quadlet_basic
 
         - name: Check files
           command: cat {{ __dir }}/{{ item }}


### PR DESCRIPTION
Cause: The code that handles secrets did not get user information for
users specified in `run_as_user`.

Consequence: The role gives an error when attempting to process secrets
which have `run_as_user`.

Fix: Get the user information for secrets that specify `run_as_user`.

Result: The role correctly handles secrets which specify `run_as_user`.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
