### PR TITLE
ci: bump ansible-lint to v25; provide collection requirements for ansible-lint

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -48,8 +48,8 @@ jobs:
           if [ -f "$meta_req_file" ] && [ -f "$test_req_file" ]; then
             coll_req_file="${{ github.workspace }}/req.yml"
             python -c 'import sys; import yaml
-          hsh1 = yaml.safe_load(open(sys.argv[0])
-          hsh2 = yaml.safe_load(open(sys.argv[1])
+          hsh1 = yaml.safe_load(open(sys.argv[0]))
+          hsh2 = yaml.safe_load(open(sys.argv[1]))
           coll = list(set(hsh1["collections"]).union(hsh2["collections"]))
           hsh1["collections"] = coll
           yaml.safe_dump(hsh1, open(sys.argv[2], "w"))' "$meta_req_file" "$test_req_file" "$coll_req_file"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -47,3 +47,4 @@ jobs:
         uses: ansible/ansible-lint@v25
         with:
           working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          requirements_file: ${{ github.workspace }}/meta/collection-requirements.yml

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -48,11 +48,11 @@ jobs:
           if [ -f "$meta_req_file" ] && [ -f "$test_req_file" ]; then
             coll_req_file="${{ github.workspace }}/req.yml"
             python -c 'import sys; import yaml
-          hsh1 = yaml.safe_load(open(sys.argv[0]))
-          hsh2 = yaml.safe_load(open(sys.argv[1]))
+          hsh1 = yaml.safe_load(open(sys.argv[1]))
+          hsh2 = yaml.safe_load(open(sys.argv[2]))
           coll = list(set(hsh1["collections"]).union(hsh2["collections"]))
           hsh1["collections"] = coll
-          yaml.safe_dump(hsh1, open(sys.argv[2], "w"))' "$meta_req_file" "$test_req_file" "$coll_req_file"
+          yaml.safe_dump(hsh1, open(sys.argv[3], "w"))' "$meta_req_file" "$test_req_file" "$coll_req_file"
           elif [ -f "$meta_req_file" ]; then
             coll_req_file="$meta_req_file"
           elif [ -f "$test_req_file" ]; then

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -44,6 +44,6 @@ jobs:
           mkdir -p "$coll_dir/.git"
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@main
+        uses: ansible/ansible-lint@v25
         with:
           working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -43,6 +43,23 @@ jobs:
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"
+          meta_req_file="${{ github.workspace }}/meta/collection-requirements.yml"
+          test_req_file="${{ github.workspace }}/tests/collection-requirements.yml"
+          if [ -f "$meta_req_file" ] && [ -f "$test_req_file" ]; then
+            coll_req_file="${{ github.workspace }}/req.yml"
+            python -c 'import sys; import yaml
+          hsh1 = yaml.safe_load(open(sys.argv[0])
+          hsh2 = yaml.safe_load(open(sys.argv[1])
+          coll = list(set(hsh1["collections"]).union(hsh2["collections"])
+          hsh1["collections"] = coll
+          yaml.safe_dump(hsh1, open(sys.argv[2], "w"))' "$meta_req_file" "$test_req_file" "$coll_req_file"
+          elif [ -f "$meta_req_file" ]; then
+            coll_req_file="$meta_req_file"
+          elif [ -f "$test_req_file" ]; then
+            coll_req_file="$test_req_file"
+          else
+            coll_req_file=""
+          fi
           echo "coll_req_file=" >> $GITHUB_OUTPUT
 
       - name: Run ansible-lint

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -60,7 +60,7 @@ jobs:
           else
             coll_req_file=""
           fi
-          echo "coll_req_file=" >> $GITHUB_OUTPUT
+          echo "coll_req_file=$coll_req_file" >> $GITHUB_OUTPUT
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v25

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -50,7 +50,7 @@ jobs:
             python -c 'import sys; import yaml
           hsh1 = yaml.safe_load(open(sys.argv[0])
           hsh2 = yaml.safe_load(open(sys.argv[1])
-          coll = list(set(hsh1["collections"]).union(hsh2["collections"])
+          coll = list(set(hsh1["collections"]).union(hsh2["collections"]))
           hsh1["collections"] = coll
           yaml.safe_dump(hsh1, open(sys.argv[2], "w"))' "$meta_req_file" "$test_req_file" "$coll_req_file"
           elif [ -f "$meta_req_file" ]; then

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -44,6 +44,6 @@ jobs:
           mkdir -p "$coll_dir/.git"
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v24
+        uses: ansible/ansible-lint@main
         with:
           working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -35,6 +35,7 @@ jobs:
           pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
+        id: collection
         run: |
           set -euxo pipefail
           TOXENV=collection lsr_ci_runtox
@@ -42,9 +43,10 @@ jobs:
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"
+          echo "coll_req_file=" >> $GITHUB_OUTPUT
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v25
         with:
           working_directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
-          requirements_file: ${{ github.workspace }}/meta/collection-requirements.yml
+          requirements_file: ${{ steps.collection.outputs.coll_req_file }}


### PR DESCRIPTION
There is a new version of ansible-lint - v25.
Newer versions of ansible-lint require the collection requirements to be
installed so it can find the modules/plugins.
Enhance our ansible-lint ci job to provide the collection requirements,
including merging the runtime meta/collection-requirements.yml with
the testing tests/collection-requirements.yml.
This should somewhat mitigate the loss of ansible-plugin-scan.
