### PR TITLE
fix: render boolean option values correctly in toml files

### DIFF
--- a/templates/toml.j2
+++ b/templates/toml.j2
@@ -3,6 +3,8 @@
 {% macro render_option(key, value) %}
 {%   if (value is iterable and ((value is not string) and (value is not mapping))) %}
 {{ key }}={{ value }}
+{%   elif (value is boolean and ((value is not string) and (value is not mapping)))  %}
+{{ key }}={{ value | lower }}
 {%   elif value is mapping and value is not string %}
 {{ key }} = [{%- for k in value %} "{{k}}={{value[k]}}", {%- endfor %}]
 {%   elif value is not string %}

--- a/templates/toml.j2
+++ b/templates/toml.j2
@@ -1,10 +1,10 @@
 {{ ansible_managed | comment }}
 {{ "system_role:podman" | comment(prefix="", postfix="") }}
 {% macro render_option(key, value) %}
-{%   if (value is iterable and ((value is not string) and (value is not mapping))) %}
-{{ key }}={{ value }}
-{%   elif (value is boolean and ((value is not string) and (value is not mapping)))  %}
+{%   if value is boolean %}
 {{ key }}={{ value | lower }}
+{%   elif (value is iterable and ((value is not string) and (value is not mapping)))  %}
+{{ key }}={{ value }}
 {%   elif value is mapping and value is not string %}
 {{ key }} = [{%- for k in value %} "{{k}}={{value[k]}}", {%- endfor %}]
 {%   elif value is not string %}


### PR DESCRIPTION
Cause: The code that formats options into TOML format does not convert boolean values to the correct string representation.

Consequence: Boolean options are not handled correctly.

Fix: Convert boolean options to string, then lower case, which is the correct TOML boolean format.

Result: Boolean options are correctly written and handled in TOML files.

Issue Tracker Tickets (Jira or BZ if any): Fixes Github #208 
