### PR TITLE
test: do not remove homedir; pause after using getsubids

### DIFF
--- a/tasks/handle_user_group.yml
+++ b/tasks/handle_user_group.yml
@@ -64,6 +64,12 @@
             __subuid_data: "{{ __podman_register_subuids.stdout.split() | list }}"
             __subgid_data: "{{ __podman_register_subgids.stdout.split() | list }}"
 
+        # on some systems, using getsubids can leave the system in a strange
+        # state temporarily, so add a pause to allow the system to recover
+        - name: Pause to let system recover from getsubids
+          pause:
+            seconds: 5
+
     - name: Check subuid, subgid files if no getsubids
       when:
         - not __podman_stat_getsubids.stat.exists

--- a/tests/tests_auth_and_security.yml
+++ b/tests/tests_auth_and_security.yml
@@ -251,10 +251,6 @@
                 name: auth_test_user1
                 state: absent
 
-            - name: Remove homedir
-              file:
-                path: /home/auth_test_user1
-                state: absent
           rescue:
             # this usually fails when the user is still running some process
             - name: See if any process is held by the user


### PR DESCRIPTION
I have noticed on some tests on some systems that removing the homedir
causes either the user session to exit, causing an Unreachable message
in the logs and a test failure, or causes subsequent tasks to fail
with Unreachable.  In addition, getsubids seems to have a similar
issue.  In this case, add a 5 second delay after the calls to getsubids
to allow the system to recover.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
