### PR TITLE
fix: Do not change the directory mode for the container parent path

### DIFF
--- a/tasks/handle_credential_files.yml
+++ b/tasks/handle_credential_files.yml
@@ -44,11 +44,16 @@
   block:
     - name: Ensure the credentials directory is present
       file:
-        path: "{{ __podman_credential_file | dirname }}"
+        path: "{{ __cred_parent_path }}"
         state: directory
         owner: "{{ __podman_credential_user }}"
         group: "{{ __podman_group }}"
-        mode: "0700"
+        mode: "{{ __cred_parent_mode }}"
+      vars:
+        __cred_parent_path: "{{ __podman_credential_file | dirname }}"
+        __cred_parent_mode: "{{ __podman_etc_containers_mode
+          if __cred_parent_path == __podman_etc_containers_path
+          else __podman_user_containers_mode }}"
 
     - name: Ensure credential file is copied
       copy:

--- a/tasks/handle_policy_json.yml
+++ b/tasks/handle_policy_json.yml
@@ -2,15 +2,21 @@
 ---
 - name: Manage policy.json
   when: podman_policy_json | length > 0
+  vars:
+    __policy_parent_path: "{{ __podman_policy_json_file | dirname }}"
   block:
     - name: Ensure policy.json parent dir exists
       file:
-        path: "{{ __podman_policy_json_file | dirname }}"
+        path: "{{ __policy_parent_path }}"
         state: directory
         owner: "{{ podman_run_as_user }}"
         group: "{{ podman_run_as_group if
           podman_run_as_group is not none else omit }}"
-        mode: "0755"
+        mode: "{{ __podman_parent_mode
+          if __policy_parent_path == __podman_parent_path
+          else __podman_etc_containers_mode
+          if podman_run_as_user == 'root'
+          else __podman_user_containers_mode }}"
 
     - name: Stat the policy.json file
       stat:

--- a/tasks/handle_storage_conf.yml
+++ b/tasks/handle_storage_conf.yml
@@ -1,15 +1,21 @@
 ---
 - name: Manage storage.conf
   when: podman_storage_conf | length > 0
+  vars:
+    __storage_parent_path: "{{ __podman_storage_conf_file | dirname }}"
   block:
     - name: Ensure storage.conf parent dir exists
       file:
-        path: "{{ __podman_storage_conf_file | dirname }}"
+        path: "{{ __storage_parent_path }}"
         state: directory
         owner: "{{ podman_run_as_user }}"
         group: "{{ podman_run_as_group if
           podman_run_as_group is not none else omit }}"
-        mode: "0755"
+        mode: "{{ __podman_parent_mode
+          if __storage_parent_path == __podman_parent_path
+          else __podman_etc_containers_mode
+          if podman_run_as_user == 'root'
+          else __podman_user_containers_mode }}"
 
     - name: Update storage config file
       template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -139,6 +139,12 @@
     __podman_policy_json_file: "{{ __podman_policy_json_system
       if podman_run_as_user == 'root' else
       __podman_user_home_dir ~ '/' ~ __podman_policy_json_user }}"
+    __podman_parent_path: "{{ __podman_etc_containers_path
+      if podman_run_as_user == 'root' else
+      __podman_user_home_dir ~ '/' ~ __podman_user_containers_path }}"
+    __podman_parent_mode: "{{ __podman_etc_containers_mode
+      if podman_run_as_user == 'root' else
+      __podman_user_containers_mode }}"
   vars:
     __podman_user_home_dir: "{{
       ansible_facts['getent_passwd'][podman_run_as_user][4] }}"

--- a/tests/tests_config_files.yml
+++ b/tests/tests_config_files.yml
@@ -39,6 +39,8 @@
         podman_policy_json:
           default:
             type: insecureAcceptAnything
+        __credential_files:
+          - file_content: this.is.a.credential
       block:
         - name: Run the role with no config to get private vars
           include_role:
@@ -74,6 +76,8 @@
             public: true
           vars:
             podman_run_as_user: user1
+            podman_run_as_group: user1
+            podman_credential_files: "{{ __credential_files }}"
 
         - name: Check that files exist and are non-null
           stat:
@@ -93,6 +97,8 @@
             public: true
           vars:
             podman_run_as_user: user1
+            podman_run_as_group: user1
+            podman_credential_files: "{{ __credential_files }}"
 
         - name: Check that files still exist and are non-null
           stat:
@@ -108,6 +114,7 @@
             public: true
           vars:
             podman_run_as_user: root
+            podman_credential_files: "{{ __credential_files }}"
 
         - name: Check that files exist and are non-null
           stat:
@@ -123,6 +130,7 @@
             public: true
           vars:
             podman_run_as_user: root
+            podman_credential_files: "{{ __credential_files }}"
 
         - name: Check that files still exist and are non-null
           stat:
@@ -158,6 +166,14 @@
             state: absent
             path: "{{ item }}"
           loop: "{{ __system_files + __user_files }}"
+
+        - name: Remove credential files
+          file:
+            state: absent
+            path: "{{ item }}"
+          loop:
+            - /root/.config/containers/auth.json
+            - /home/user1/.config/containers/auth.json
 
         - name: Restore system config files
           # noqa command-instead-of-module

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -37,51 +37,64 @@ __podman_required_facts:
 __podman_required_facts_subsets: "{{ ['!all', '!min'] +
   __podman_required_facts }}"
 
+# location for system containers directory
+__podman_etc_containers_path: "/etc/containers"
+
+# location for user containers directory
+# relative to $HOME
+__podman_user_containers_path: ".config/containers"
+
+# mode for __podman_etc_containers_path
+__podman_etc_containers_mode: "0755"
+
+# mode for user __podman_user_containers_path
+__podman_user_containers_mode: "0700"
+
 __podman_containers_conf_file_name: 50-systemroles.conf
 __podman_containers_conf_system: >-
-  /etc/containers/containers.conf.d/{{ __podman_containers_conf_file_name }}
+  {{ __podman_etc_containers_path }}/containers.conf.d/{{ __podman_containers_conf_file_name }}
 # relative to $HOME
 __podman_containers_conf_user: >-
-  .config/containers/containers.conf.d/{{ __podman_containers_conf_file_name }}
+  {{ __podman_user_containers_path }}/containers.conf.d/{{ __podman_containers_conf_file_name }}
 
 __podman_registries_conf_file_name: 50-systemroles.conf
 __podman_registries_conf_system: >-
-  /etc/containers/registries.conf.d/{{ __podman_registries_conf_file_name }}
+  {{ __podman_etc_containers_path }}/registries.conf.d/{{ __podman_registries_conf_file_name }}
 # relative to $HOME
 __podman_registries_conf_user: >-
-  .config/containers/registries.conf.d/{{ __podman_registries_conf_file_name }}
+  {{ __podman_user_containers_path }}/registries.conf.d/{{ __podman_registries_conf_file_name }}
 
 __podman_storage_conf_file_name: storage.conf
 __podman_storage_conf_system: >-
-  /etc/containers/{{ __podman_storage_conf_file_name }}
+  {{ __podman_etc_containers_path }}/{{ __podman_storage_conf_file_name }}
 # relative to $HOME
 __podman_storage_conf_user: >-
-  .config/containers/{{ __podman_storage_conf_file_name }}
+  {{ __podman_user_containers_path }}/{{ __podman_storage_conf_file_name }}
 
 __podman_policy_json_file_name: policy.json
 __podman_policy_json_system: >-
   /etc/containers/{{ __podman_policy_json_file_name }}
 # relative to $HOME
 __podman_policy_json_user: >-
-  .config/containers/{{ __podman_policy_json_file_name }}
+  {{ __podman_user_containers_path }}/{{ __podman_policy_json_file_name }}
 
 # location for system kubernetes yaml files
-__podman_system_kube_path: "/etc/containers/ansible-kubernetes.d"
+__podman_system_kube_path: "{{ __podman_etc_containers_path }}/ansible-kubernetes.d"
 
 # location for user kubernetes yaml files
-__podman_user_kube_path: "/.config/containers/ansible-kubernetes.d"
+__podman_user_kube_path: "/{{ __podman_user_containers_path }}/ansible-kubernetes.d"
 
 # location for system quadlet files
-__podman_system_quadlet_path: "/etc/containers/systemd"
+__podman_system_quadlet_path: "{{ __podman_etc_containers_path }}/systemd"
 
 # location for user quadlet files
-__podman_user_quadlet_path: "/.config/containers/systemd"
+__podman_user_quadlet_path: "/{{ __podman_user_containers_path }}/systemd"
 
 # location for user certs_d
-__podman_user_certs_d_path: "/.config/containers/certs.d"
+__podman_user_certs_d_path: "/{{ __podman_user_containers_path }}/certs.d"
 
 # location for system certs_d
-__podman_system_certs_d_path: "/etc/containers/certs.d"
+__podman_system_certs_d_path: "{{ __podman_etc_containers_path }}/certs.d"
 
 # BEGIN - DO NOT EDIT THIS BLOCK - rh distros variables
 # Ansible distribution identifiers that the role treats like RHEL


### PR DESCRIPTION
Cause: The role was using two different modes for the common parent path
for various config files and authentication files.

Consequence: The role would change the parent path mode every time the role
is run if managing both authentication and config files.

Fix: Use a consistent mode for the parent path.

Result: The role does not report changed: true unnecessarily.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

This fixes https://github.com/linux-system-roles/podman/issues/210

This changes the tests_config_files.yml to add an auth file to check
if the path mode is changed.
