### PR TITLE
refactor: fix ansible-test issues - unicode_literals, format string

### DIFF
--- a/filter_plugins/podman_to_toml.py
+++ b/filter_plugins/podman_to_toml.py
@@ -3,7 +3,7 @@
 # Copyright: (c) 2025, Red Hat, Inc.
 #
 """Convert given python object to TOML string representation."""
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
@@ -132,7 +132,7 @@ def dump(obj, fout, sort_keys=False):
             elif v is None:
                 # based on mojombo's comment: https://github.com/toml-lang/toml/issues/146#issuecomment-25019344
                 fout.write(
-                    '#{} = null  # To use: uncomment and replace null with value\n'.format(_escape_id(k)))
+                    '#{0} = null  # To use: uncomment and replace null with value\n'.format(_escape_id(k)))
                 has_kv = True
             else:
                 fout.write('{0} = {1}\n'.format(_escape_id(k), _format_value(v)))
@@ -157,6 +157,6 @@ class FilterModule(object):
                 if isinstance(data[section], dict):
                     for key, value in list(data[section].items()):
                         if isinstance(value, dict):
-                            data[section][key] = ["{}={}".format(kk, vv) for kk, vv in value.items()]
+                            data[section][key] = ["{0}={1}".format(kk, vv) for kk, vv in value.items()]
 
         return dumps(data)


### PR DESCRIPTION
ansible-test does not like the use of unicode_literals

```
ERROR: Found 1 no-unicode-literals issue(s) which need to be resolved:
ERROR: plugins/filter/podman_to_toml.py:6:67: do not use `unicode_literals`
```

ansible-test requires field numbering in format specs:
```
ERROR: plugins/filter/podman_to_toml.py:135:20: ansible-format-automatic-specification: Format string contains automatic field numbering specification
ERROR: plugins/filter/podman_to_toml.py:160:50: ansible-format-automatic-specification: Format string contains automatic field numbering specification
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
