### PR TITLE
docs(changelog): version 1.8.2 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.8.2] - 2025-07-09
+--------------------
+
+### Other Changes
+
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#226)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#228)
+- ci: Add support for bootc end-to-end validation tests (#229)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#230)
+- refactor: support Ansible 2.19 (#231)
+
 [1.8.1] - 2025-05-05
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.8.2

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare v1.8.2 release by updating the changelog and documentation to reflect recent CI and testing enhancements

Enhancements:
- Document CI and testing improvements including tox-lsr bump, Fedora 42 support, qemu/kvm and bootc validation tests, Python 3.13, and Ansible 2.19

Documentation:
- Add 1.8.2 entry to CHANGELOG.md
- Update README.html version to 1.8.2