### PR TITLE
fix: do not mix facts with vars

### DIFF
--- a/tasks/handle_certs_d.yml
+++ b/tasks/handle_certs_d.yml
@@ -19,21 +19,20 @@
 - name: Check user and group information
   include_tasks: handle_user_group.yml
   vars:
+    __podman_handle_user: "{{ __podman_user }}"
     __podman_spec_item: "{{ __podman_cert_spec_item }}"
 
 - name: Set per-cert spec variables part 2
-  set_fact:
-    __podman_user_home_dir: "{{
-      ansible_facts['getent_passwd'][__podman_user][4] }}"
-
-- name: Set per-cert spec variables part 3
   set_fact:
     __podman_certs_d_path: "{{ (__podman_user_home_dir ~
       __podman_user_certs_d_path
       if __podman_rootless else __podman_system_certs_d_path) ~
       '/' ~ __podman_cert_spec_item['registry_host'] }}"
+  vars:
+    __podman_user_home_dir: "{{
+      ansible_facts['getent_passwd'][__podman_user][4] }}"
 
-- name: Set per-cert spec variables part 4
+- name: Set per-cert spec variables part 3
   set_fact:
     __podman_cert_file_list:
       - dest: "{{ __podman_certs_d_path ~ '/' ~

--- a/tasks/handle_credential_files.yml
+++ b/tasks/handle_credential_files.yml
@@ -11,7 +11,7 @@
 - name: Check user and group information
   include_tasks: handle_user_group.yml
   vars:
-    __podman_user: "{{ __podman_credential_user }}"
+    __podman_handle_user: "{{ __podman_credential_user }}"
     __podman_spec_item: "{{ __podman_credential_item }}"
 
 - name: Set credential variables

--- a/tasks/handle_kube_spec.yml
+++ b/tasks/handle_kube_spec.yml
@@ -66,6 +66,7 @@
 - name: Check user and group information
   include_tasks: handle_user_group.yml
   vars:
+    __podman_handle_user: "{{ __podman_user }}"
     __podman_spec_item: "{{ __podman_kube_spec_item }}"
 
 - name: Fail if no kube spec is given
@@ -81,8 +82,6 @@
   set_fact:
     __podman_xdg_runtime_dir: >-
       /run/user/{{ ansible_facts["getent_passwd"][__podman_user][1] }}
-    __podman_user_home_dir: "{{
-      ansible_facts['getent_passwd'][__podman_user][4] }}"
     __podman_systemd_scope: "{{ __podman_systemd_unit_scope
       if __podman_systemd_unit_scope
       and __podman_systemd_unit_scope | length > 0
@@ -96,6 +95,9 @@
     __podman_kube_path: "{{ __podman_user_home_dir ~
       __podman_user_kube_path
       if __podman_rootless else __podman_system_kube_path }}"
+  vars:
+    __podman_user_home_dir: "{{
+      ansible_facts['getent_passwd'][__podman_user][4] }}"
 
 - name: Set per-container variables part 5
   set_fact:

--- a/tasks/handle_quadlet_spec.yml
+++ b/tasks/handle_quadlet_spec.yml
@@ -97,14 +97,13 @@
 - name: Check user and group information
   include_tasks: handle_user_group.yml
   vars:
+    __podman_handle_user: "{{ __podman_user }}"
     __podman_spec_item: "{{ __podman_quadlet_spec_item }}"
 
 - name: Set per-container variables part 3
   set_fact:
     __podman_xdg_runtime_dir: >-
       /run/user/{{ ansible_facts["getent_passwd"][__podman_user][1] }}
-    __podman_user_home_dir: "{{
-      ansible_facts['getent_passwd'][__podman_user][4] }}"
     __podman_systemd_scope: "{{ __podman_systemd_unit_scope
       if __podman_systemd_unit_scope
       and __podman_systemd_unit_scope | length > 0
@@ -140,6 +139,9 @@
     __podman_quadlet_path: "{{ __podman_user_home_dir ~
       __podman_user_quadlet_path
       if __podman_rootless else __podman_system_quadlet_path }}"
+  vars:
+    __podman_user_home_dir: "{{
+      ansible_facts['getent_passwd'][__podman_user][4] }}"
 
 - name: Get kube yaml contents
   slurp:

--- a/tasks/handle_secret.yml
+++ b/tasks/handle_secret.yml
@@ -8,6 +8,7 @@
 - name: Check user and group information
   include_tasks: handle_user_group.yml
   vars:
+    __podman_handle_user: "{{ __podman_user }}"
     __podman_spec_item: "{{ __podman_secret_item }}"
     __podman_check_subids: false
   no_log: true

--- a/tasks/handle_user_group.yml
+++ b/tasks/handle_user_group.yml
@@ -1,18 +1,26 @@
+# Inputs:
+# __podman_handle_user: string - name of user
+# __podman_spec_item: dict - object with more information
+# Outputs:
+# ansible_facts["getent_passwd"][__podman_handle_user]
+# __podman_group
+# podman_subuid_info
+# podman_subgid_info
 ---
 - name: Get user information
   getent:
     database: passwd
-    key: "{{ __podman_user }}"
+    key: "{{ __podman_handle_user }}"
     fail_key: false
   when: "'getent_passwd' not in ansible_facts or
-    __podman_user not in ansible_facts['getent_passwd']"
+    __podman_handle_user not in ansible_facts['getent_passwd']"
 
 - name: Fail if user does not exist
   fail:
     msg: >
-      The given podman user [{{ __podman_user }}] does not exist -
+      The given podman user [{{ __podman_handle_user }}] does not exist -
       cannot continue
-  when: not ansible_facts["getent_passwd"][__podman_user]
+  when: not ansible_facts["getent_passwd"][__podman_handle_user]
 
 - name: Set group for podman user
   set_fact:
@@ -23,7 +31,7 @@
       {%- elif podman_run_as_group is not none -%}
       {{ podman_run_as_group }}
       {%- else -%}
-      {{ ansible_facts["getent_passwd"][__podman_user][2] }}
+      {{ ansible_facts["getent_passwd"][__podman_handle_user][2] }}
       {%- endif -%}
 
 - name: Check subids
@@ -37,27 +45,27 @@
     # does not work for root
     - name: Use getsubids if available
       when:
-        - __podman_user not in ["root", "0"]
+        - __podman_handle_user not in ["root", "0"]
         - __podman_stat_getsubids.stat.exists
       block:
         - name: Check with getsubids for user subuids
-          command: getsubids {{ __podman_user | quote }}
+          command: getsubids {{ __podman_handle_user | quote }}
           changed_when: false
           register: __podman_register_subuids
 
         - name: Check with getsubids for user subgids
-          command: getsubids -g {{ __podman_user | quote }}
+          command: getsubids -g {{ __podman_handle_user | quote }}
           changed_when: false
           register: __podman_register_subgids
 
         - name: Set user subuid and subgid info
           set_fact:
             podman_subuid_info: "{{ podman_subuid_info | d({}) |
-              combine({__podman_user:
+              combine({__podman_handle_user:
                 {'start': __subuid_data[2] | int, 'range': __subuid_data[3] | int}})
               if __subuid_data | length > 0 else podman_subuid_info | d({}) }}"
             podman_subgid_info: "{{ podman_subgid_info | d({}) |
-              combine({__podman_user:
+              combine({__podman_handle_user:
                 {'start': __subgid_data[2] | int, 'range': __subgid_data[3] | int}})
               if __subgid_data | length > 0 else podman_subgid_info | d({}) }}"
           vars:
@@ -67,7 +75,7 @@
     - name: Check subuid, subgid files if no getsubids
       when:
         - not __podman_stat_getsubids.stat.exists
-        - __podman_user not in ["root", "0"]
+        - __podman_handle_user not in ["root", "0"]
       block:
         - name: Get subuid file
           slurp:
@@ -82,35 +90,35 @@
         - name: Set user subuid and subgid info
           set_fact:
             podman_subuid_info: "{{ podman_subuid_info | d({}) |
-              combine({__podman_user:
+              combine({__podman_handle_user:
                 {'start': __subuid_data[1] | int, 'range': __subuid_data[2] | int}})
               if __subuid_data else podman_subuid_info | d({}) }}"
             podman_subgid_info: "{{ podman_subgid_info | d({}) |
-              combine({__podman_user:
+              combine({__podman_handle_user:
                 {'start': __subgid_data[1] | int, 'range': __subgid_data[2] | int}})
               if __subgid_data else podman_subgid_info | d({}) }}"
           vars:
             __subuid_match_line: "{{
               (__podman_register_subuids.content | b64decode).split('\n') | list |
-              select('match', '^' ~ __podman_user ~ ':') | list }}"
+              select('match', '^' ~ __podman_handle_user ~ ':') | list }}"
             __subuid_data: "{{ __subuid_match_line[0].split(':') | list
               if __subuid_match_line else none }}"
             __subgid_match_line: "{{
               (__podman_register_subgids.content | b64decode).split('\n') | list |
-              select('match', '^' ~ __podman_user ~ ':') | list }}"
+              select('match', '^' ~ __podman_handle_user ~ ':') | list }}"
             __subgid_data: "{{ __subgid_match_line[0].split(':') | list
               if __subgid_match_line else none }}"
 
         - name: Fail if user not in subuid file
           fail:
             msg: >
-              The given podman user [{{ __podman_user }}] is not in the
+              The given podman user [{{ __podman_handle_user }}] is not in the
               /etc/subuid file - cannot continue
-          when: not __podman_user in podman_subuid_info
+          when: not __podman_handle_user in podman_subuid_info
 
         - name: Fail if user not in subgid file
           fail:
             msg: >
-              The given podman user [{{ __podman_user }}] is not in the
+              The given podman user [{{ __podman_handle_user }}] is not in the
               /etc/subgid file - cannot continue
-          when: not __podman_user in podman_subgid_info
+          when: not __podman_handle_user in podman_subgid_info

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,7 +122,7 @@
 - name: Check user and group information
   include_tasks: handle_user_group.yml
   vars:
-    __podman_user: "{{ podman_run_as_user }}"
+    __podman_handle_user: "{{ podman_run_as_user }}"
     __podman_spec_item: {}
 
 - name: Set config file paths


### PR DESCRIPTION
Cause: The variables __podman_user and __podman_user_home_dir were being
set by both `vars` and `set_fact`.  This causes unpredictable and
undefined behavior.

Consequence: When managing resources for two different users, the
variables __podman_user and __podman_user_home_dir were using the old
values from the first user, so config files for the first user were
being used for the second user.

Fix: Ensure that __podman_user is only ever set with `set_fact`, and
__podman_user_home_dir is only ever set with `vars`.  Refactor the
code to use __podman_handle_user instead of __podman_user where a
`vars` could be used.

Result: Data for multiple users is kept separate.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prevent cross-user data contamination by introducing a dedicated __podman_handle_user variable for user tasks and using vars instead of set_fact for __podman_user_home_dir.

Bug Fixes:
- Stop mixing facts and vars for __podman_user and __podman_user_home_dir to avoid stale user data when managing multiple users

Enhancements:
- Refactor handle_user_group and include_tasks calls to use __podman_handle_user consistently
- Move __podman_user_home_dir assignment into vars blocks instead of set_fact