### PR TITLE
ci: fix markdown formatting for contributing.md to pass markdownlint

### DIFF
--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -31,6 +31,15 @@ prepare:
       if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
       fi
+  # Replace with feature: epel: enabled once https://github.com/teemtee/tmt/pull/3128 is merged
+  - name: Enable epel to install beakerlib
+    script: |
+      # CS 10 and Fedora doesn't require epel
+      if grep -q -e 'CentOS Stream release 10' -e 'Fedora release' /etc/redhat-release; then
+        exit 0
+      fi
+      yum install epel-release yum-utils -y
+      yum-config-manager --enable epel epel-debuginfo epel-source
 discover:
   - name: Prepare managed node
     how: fmf
@@ -53,11 +62,5 @@ discover:
   #   filter: tag:reserve_system
   #   url: https://github.com/linux-system-roles/tft-tests
   #   ref: main
-adjust:
-  - when: distro == rhel-9 or distro == centos-stream-9 or distro == rhel-10 or distro == centos-stream-10
-    prepare+:
-      - how: feature
-        epel: enabled
-        order: 10
 execute:
-  how: tmt
+    how: tmt


### PR DESCRIPTION
fix markdown formatting for contributing.md to pass markdownlint

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Fix Markdown formatting in CONTRIBUTING.md to comply with markdownlint rules.

Documentation:
- Adjust heading levels and punctuation to meet linting standards
- Ensure proper blank lines around lists and code blocks
- Normalize list indentation and punctuation for consistency