### PR TITLE
ci: use versioned upload-artifact instead of master; bump codeql-action to v4; bump upload-artifact to v5

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -91,7 +91,7 @@ jobs:
         run: cp ${{ env.RELEASE_VERSION }}/README.html docs/index.html
 
       - name: Upload README.html as an artifact
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v5
         with:
           name: README.html
           path: ${{ env.RELEASE_VERSION }}/README.html

--- a/.github/workflows/test_converting_readme.yml
+++ b/.github/workflows/test_converting_readme.yml
@@ -40,7 +40,7 @@ jobs:
             --output README.html README.md
 
       - name: Upload README.html as an artifact
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v5
         with:
           name: README.html
           path: README.html


### PR DESCRIPTION
use versioned upload-artifact instead of master

bump codeql-action from v3 to v4

bump upload-artifact from v4 to v5

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update GitHub Actions workflows to use explicit version tags for actions

CI:
- Use actions/upload-artifact@v5 instead of master in build_docs.yml and test_converting_readme.yml
- Bump actions/codeql-action from v3 to v4