### PR TITLE
refactor: handle INJECT_FACTS_AS_VARS=false by using ansible_facts instead

### DIFF
--- a/README-ostree.md
+++ b/README-ostree.md
@@ -20,8 +20,8 @@ Usage:
 .ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
 ```
 
-`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
-and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_facts["distribution"]`
+and `ansible_facts["distribution_version"]` - for example, `Fedora-38`, `CentOS-8`,
 `RedHat-9.4`
 
 `FORMAT` is one of `toml`, `json`, `yaml`, `raw`

--- a/tests/vars/rh_distros_vars.yml
+++ b/tests/vars/rh_distros_vars.yml
@@ -14,7 +14,7 @@ __podman_rh_distros:
 __podman_rh_distros_fedora: "{{ __podman_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__podman_is_rh_distro: "{{ ansible_distribution in __podman_rh_distros }}"
+__podman_is_rh_distro: "{{ ansible_facts['distribution'] in __podman_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__podman_is_rh_distro_fedora: "{{ ansible_distribution in __podman_rh_distros_fedora }}"
+__podman_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __podman_rh_distros_fedora }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -108,8 +108,8 @@ __podman_rh_distros:
 __podman_rh_distros_fedora: "{{ __podman_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__podman_is_rh_distro: "{{ ansible_distribution in __podman_rh_distros }}"
+__podman_is_rh_distro: "{{ ansible_facts['distribution'] in __podman_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__podman_is_rh_distro_fedora: "{{ ansible_distribution in __podman_rh_distros_fedora }}"
+__podman_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __podman_rh_distros_fedora }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Align distro-related conditionals and documentation with Ansible 2.20+ by referencing ansible_facts["distribution"] and ansible_facts["distribution_version"] instead of deprecated ansible_distribution variables.