### PR TITLE
ci: use ANSIBLE_INJECT_FACT_VARS=false by default for testing

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -44,6 +44,7 @@ jobs:
 
     env:
       TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
+      ANSIBLE_INJECT_FACT_VARS: "false"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -168,6 +168,7 @@ jobs:
             SR_ARTIFACTS_DIR=${{ steps.set_vars.outputs.ARTIFACTS_DIR }};\
             SR_TEST_LOCAL_CHANGES=false;\
             SR_LSR_USER=${{ vars.SR_LSR_USER }};\
+            SR_ANSIBLE_INJECT_FACT_VARS=false;\
             SR_ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
           secrets: "SR_LSR_DOMAIN=${{ secrets.SR_LSR_DOMAIN }};\


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

In order to ensure that commits and PRs conform to this, use
ANSIBLE_INJECT_FACT_VARS=false by default in our CI testing.

Update README-ostree.md if needed.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enforce Ansible fact variable injection settings in CI to align tests with upcoming Ansible defaults.

CI:
- Set ANSIBLE_INJECT_FACT_VARS=false in qemu-kvm integration test workflow to run CI with fact injection disabled.
- Propagate the Ansible fact injection flag via SR_ANSIBLE_INJECT_FACT_VARS in the tft workflow so Terraform-based tests also run with injection disabled.