### PR TITLE
refactor: do not reassign __vars_file, use separate var

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -31,7 +31,7 @@
         __podman_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
 
 - name: Set platform/version specific variables
-  include_vars: "{{ __vars_file }}"
+  include_vars: "{{ __vars_file_full }}"
   loop:
     - "{{ ansible_facts['os_family'] }}.yml"
     - "{{ ansible_facts['distribution'] }}.yml"
@@ -44,8 +44,8 @@
   loop_control:
     loop_var: __vars_file
   vars:
-    __vars_file: "{{ role_path }}/vars/{{ __vars_file }}"
-  when: __vars_file is file
+    __vars_file_full: "{{ role_path }}/vars/{{ __vars_file }}"
+  when: __vars_file_full is file
 
 - name: Determine if system is booted with systemd
   when: __podman_is_booted is not defined


### PR DESCRIPTION
ansible-lint does not like doing

```
vars:
  __vars_file: something/{{ __vars_file }}
```

so use a separate variable

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Use a dedicated __vars_file_full variable for include_vars paths and existence checks instead of mutating __vars_file.