### PR TITLE
feat: Parametrize no_log usage in podman role

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,14 @@ for custom handling of the reboot requirement. If this variable is not set,
 the role will fail to ensure the reboot requirement is not overlooked.
 For non-transactional update systems, this variable is ignored.
 
+### podman_secure_logging
+
+Boolean - default is `true`. If `true`, the role suppresses sensitive output from tasks that handle credentials, secrets, and other sensitive data by setting `no_log: true` on those tasks.
+This prevents passwords, API tokens, registry credentials, and similar sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you can temporarily set `podman_secure_logging: false` to see the full output from these tasks.
+However, be aware that this may expose sensitive information in logs, so it should only be used in development or troubleshooting scenarios.
+
 ## Variables Exported by the Role
 
 ### podman_version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -145,3 +145,7 @@ podman_transactional_update_reboot_ok: null
 
 # var to set to use new TOML formatter
 podman_use_new_toml_formatter: false
+
+# If true, suppress potentially sensitive output from tasks that
+# handle credentials, secrets, and other sensitive data.
+podman_secure_logging: true

--- a/tasks/cleanup_quadlet_spec.yml
+++ b/tasks/cleanup_quadlet_spec.yml
@@ -115,7 +115,7 @@
         - not __podman_rootless or __podman_xdg_stat.stat.exists
         - __podman_service_name is not none
         - __podman_service_name | length > 0
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
     - name: Remove volumes
       command: podman volume rm {{ item | quote }}
@@ -142,7 +142,7 @@
           map(attribute='persistentVolumeClaim') | selectattr('claimName', 'defined') |
           map(attribute='claimName') | list }}"
         __volume_names: "{{ __config_maps + __secrets + __pvcs }}"
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
     - name: Clear parsed podman variable
       set_fact:
@@ -209,7 +209,7 @@
           command: podman secret ls -n -q
           register: __podman_test_debug_secrets
           changed_when: false
-          no_log: true
+          no_log: "{{ podman_secure_logging }}"
           become: "{{ __podman_rootless | ternary(true, omit) }}"
           become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
           environment:
@@ -219,7 +219,7 @@
           command: podman pod ls -n -q
           register: __podman_test_debug_pods
           changed_when: false
-          no_log: true
+          no_log: "{{ podman_secure_logging }}"
           become: "{{ __podman_rootless | ternary(true, omit) }}"
           become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
           environment:
@@ -227,6 +227,7 @@
 
         - name: For testing and debugging - services
           service_facts:
+          no_log: "{{ ansible_verbosity < 2 }}"
           become: "{{ __podman_rootless | ternary(true, omit) }}"
           become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
           environment:

--- a/tasks/handle_certs_d.yml
+++ b/tasks/handle_certs_d.yml
@@ -59,7 +59,7 @@
            else 'ca.crt') }}"
         content: "{{ __podman_cert_spec_item['ca_cert_content'] | d('') }}"
         src: "{{ __podman_cert_spec_item['ca_cert_src'] | d('') }}"
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Create TLS files
   when:
@@ -84,7 +84,7 @@
         mode: "0600"
       when: (item.content | length > 0) or (item.src | length > 0)
       loop: "{{ __podman_cert_file_list }}"
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
 - name: Remove TLS files
   when:
@@ -96,7 +96,7 @@
         path: "{{ item.dest }}"
         state: absent
       loop: "{{ __podman_cert_file_list }}"
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
     - name: Find files in certs.d directory
       find:
@@ -104,11 +104,11 @@
         file_type: any
         hidden: true
       register: __certs_d_dir_files
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
     - name: Ensure the certs.d directory is absent if empty
       file:
         path: "{{ __podman_certs_d_path }}"
         state: absent
       when: __certs_d_dir_files.matched == 0
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"

--- a/tasks/handle_credential_files.yml
+++ b/tasks/handle_credential_files.yml
@@ -35,7 +35,7 @@
     __authdir: "{{
       ansible_facts['getent_passwd'][__podman_credential_user][4] ~
       '/.config/containers/' }}"
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Handle state present
   when:
@@ -65,7 +65,7 @@
       when:
         - __podman_credential_file_src is not none
         - __podman_credential_file_src | length > 0
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
     - name: Ensure credential file content is present
       copy:
@@ -78,7 +78,7 @@
         - __podman_credential_str is not none
         - __podman_credential_str | length > 0
         - not __podman_credential_file_src
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
 - name: Handle state absent
   when:
@@ -89,7 +89,7 @@
       file:
         path: "{{ __podman_credential_file }}"
         state: absent
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
     - name: Find files in credentials directory
       find:
@@ -97,7 +97,7 @@
         file_type: any
         hidden: true
       register: __credential_dir_files
-      no_log: true
+      no_log: "{{ podman_secure_logging }}"
 
     - name: Ensure the credentials directory is absent if empty
       file:

--- a/tasks/handle_image_cache.yml
+++ b/tasks/handle_image_cache.yml
@@ -37,7 +37,7 @@
     - __podman_image_updated is failed
     - not __podman_continue_if_pull_fails
   register: __podman_image_updated
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Create script to update image cache
   template:

--- a/tasks/handle_images.yml
+++ b/tasks/handle_images.yml
@@ -23,7 +23,7 @@
   become: "{{ __podman_rootless | ternary(true, omit) }}"
   become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
   loop: "{{ __podman_images | unique | list }}"
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Handle images when not booted
   include_tasks: handle_image_cache.yml

--- a/tasks/handle_kube_spec.yml
+++ b/tasks/handle_kube_spec.yml
@@ -130,7 +130,7 @@
     __podman_validate_certs: "{{ __podman_kube_spec_item['validate_certs']
       if 'validate_certs' in __podman_kube_spec_item
       else podman_validate_certs }}"
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Get service name using systemd-escape
   command: >-

--- a/tasks/handle_quadlet_spec.yml
+++ b/tasks/handle_quadlet_spec.yml
@@ -228,7 +228,7 @@
     __podman_validate_certs: "{{ __podman_quadlet_spec_item['validate_certs']
       if 'validate_certs' in __podman_quadlet_spec_item
       else podman_validate_certs }}"
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Cleanup quadlets
   include_tasks: cleanup_quadlet_spec.yml

--- a/tasks/handle_secret.yml
+++ b/tasks/handle_secret.yml
@@ -11,7 +11,7 @@
     __podman_handle_user: "{{ __podman_user }}"
     __podman_spec_item: "{{ __podman_secret_item }}"
     __podman_check_subids: false
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Set variables part 2
   set_fact:
@@ -47,7 +47,7 @@
   become: "{{ __podman_rootless | ternary(true, omit) }}"
   become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
   when: not __podman_rootless or __podman_xdg_stat.stat.exists
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
   vars:
     supported_params: [data, driver, driver_opts, executable, force, name, skip_existing, state]
     __params: "{{ __podman_secret_item | dict2items |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Gather the package facts
   package_facts:
-  no_log: true
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Enable copr if requested
   include_tasks: enable_copr.yml
@@ -189,7 +189,7 @@
   loop: "{{ podman_registry_certificates }}"
   loop_control:
     loop_var: __podman_cert_spec_item
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Handle credential files - present
   include_tasks: handle_credential_files.yml
@@ -198,28 +198,28 @@
   loop: "{{ podman_credential_files }}"
   loop_control:
     loop_var: __podman_credential_item
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Handle secrets
   include_tasks: handle_secret.yml
   loop: "{{ podman_secrets }}"
   loop_control:
     loop_var: __podman_secret_item
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Handle Kubernetes specifications
   include_tasks: handle_kube_spec.yml
   loop: "{{ podman_kube_specs }}"
   loop_control:
     loop_var: __podman_kube_spec_item
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Handle Quadlet specifications
   include_tasks: handle_quadlet_spec.yml
   loop: "{{ podman_quadlet_specs }}"
   loop_control:
     loop_var: __podman_quadlet_spec_item
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Cancel linger
   include_tasks: cancel_linger.yml
@@ -235,7 +235,7 @@
   loop: "{{ podman_credential_files }}"
   loop_control:
     loop_var: __podman_credential_item
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Handle certs.d files - absent
   include_tasks: handle_certs_d.yml
@@ -244,7 +244,7 @@
   loop: "{{ podman_registry_certificates }}"
   loop_control:
     loop_var: __podman_cert_spec_item
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Record role success fingerprint
   sr_fingerprint:

--- a/tasks/parse_quadlet_file.yml
+++ b/tasks/parse_quadlet_file.yml
@@ -7,7 +7,7 @@
   slurp:
     path: "{{ __podman_quadlet_file }}"
   register: __podman_quadlet_raw
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Parse quadlet file
   set_fact:
@@ -15,7 +15,7 @@
   when:
     - __podman_service_name is not none
     - __podman_service_name | length > 0
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Parse quadlet yaml file
   set_fact:
@@ -25,7 +25,7 @@
     - __podman_service_name is none or __podman_service_name | length == 0
     - __podman_quadlet_file.endswith(".yml") or
       __podman_quadlet_file.endswith(".yaml")
-  no_log: true
+  no_log: "{{ podman_secure_logging }}"
 
 - name: Reset raw variable
   set_fact:


### PR DESCRIPTION
Feature: Introduce the `podman_secure_logging` variable that defaults to `true` and using verbosity-based logging for facts modules.

Reason:  Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues. Additionally, package_facts and service_facts produce verbose output that clutters logs during normal operation.

Result:                                                                                                             
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ podman_secure_logging }}", allowing users to set podman_secure_logging: false for debugging while maintaining secure defaults (true)                                                                                                                                   
  - package_facts and service_facts now use no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - New variable podman_secure_logging documented in README.md with guidance on when to disable it                                                                           
  - Users can now debug credential and secret issues without modifying role code                                                                                             
 
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Parameterize secure logging behavior in the podman role and introduce verbosity-based logging for facts gathering.

Enhancements:
- Replace hard-coded no_log: true on sensitive tasks with the configurable podman_secure_logging variable.
- Add verbosity-based no_log control to package_facts and service_facts tasks to reduce noisy output by default.
- Introduce podman_secure_logging default variable and document its purpose and usage in the role README.