### PR TITLE
fix: Use verbosity level 3 for no_log

### DIFF
--- a/tasks/cleanup_quadlet_spec.yml
+++ b/tasks/cleanup_quadlet_spec.yml
@@ -227,7 +227,7 @@
 
         - name: For testing and debugging - services
           service_facts:
-          no_log: "{{ ansible_verbosity < 2 }}"
+          no_log: "{{ ansible_verbosity < 3 }}"
           become: "{{ __podman_rootless | ternary(true, omit) }}"
           become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
           environment:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Gather the package facts
   package_facts:
-  no_log: "{{ ansible_verbosity < 2 }}"
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Enable copr if requested
   include_tasks: enable_copr.yml


### PR DESCRIPTION
Use `ansible_verbosity < 3` instead of `< 2` to show output with `-vvv` or higher.

## Summary by Sourcery

Bug Fixes:
- Align no_log conditions with expected verbosity behavior so debugging output appears at verbosity level 3 and above.