### PR TITLE
test: use list-units instead of service_facts for user units and fix test checks

### DIFF
--- a/tasks/cleanup_quadlet_spec.yml
+++ b/tasks/cleanup_quadlet_spec.yml
@@ -225,10 +225,34 @@
           environment:
             XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
 
-        - name: For testing and debugging - services
-          service_facts:
-          no_log: "{{ ansible_verbosity < 3 }}"
+        # NOTE: service_facts does not work for rootless - no way to specify user scope and user
+        # the usual tricks like using become/become_user and/or remote_user do not work for rootless
+        - name: For testing and debugging - get services
+          # noqa command-instead-of-module
+          command: >-
+            systemctl --{{ __podman_systemd_scope }} list-units -a -l --no-legend -q --plain --no-pager
+            {{ __podman_test_debug_service_pattern | d("") }}
           become: "{{ __podman_rootless | ternary(true, omit) }}"
           become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
           environment:
             XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+          register: __podman_test_service_output
+          changed_when: false
+
+        - name: For testing and debugging - clear
+          set_fact:
+            __podman_test_debug_services: {}
+
+        - name: For testing and debugging - create dict of quadlet services
+          set_fact:
+            __podman_test_debug_services: "{{ __podman_test_debug_services | combine({item.0: __item_dict}) }}"
+          loop: "{{ __service_list_lists }}"
+          vars:
+            __service_list_lists: "{{ __podman_test_service_output.stdout_lines |
+              reject('search', 'not-found') | reject('search', 'masked') | reject('search', 'failed') |
+              map('trim') | map('split') | list }}"
+            __item_dict:
+              name: "{{ item.0 }}"
+              loaded: "{{ item.1 }}"
+              active: "{{ item.2 }}"
+              status: "{{ item.3 }}"

--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -271,6 +271,7 @@
           vars:
             podman_prune_images: true
             __podman_test_debug: true
+            __podman_test_debug_service_pattern: "*quadlet*"
             podman_run_as_user: user_quadlet_basic
             __absent: {"state":"absent"}
             podman_secrets: "{{ __podman_secrets | map('combine', __absent) |
@@ -289,9 +290,8 @@
               - __podman_test_debug_volumes.stdout == ""
               - __podman_test_debug_containers.stdout == ""
               - __podman_test_debug_secrets.stdout == ""
-              - ansible_facts["services"] | dict2items |
-                rejectattr("value.status", "match", "not-found") |
-                selectattr("key", "match", "quadlet-demo") |
+              - __podman_test_debug_services | dict2items |
+                selectattr("key", "match", "quadlet-basic") |
                 list | length == 0
           when: __podman_is_booted | bool
 
@@ -362,6 +362,7 @@
               vars:
                 podman_prune_images: true
                 __podman_test_debug: true
+                __podman_test_debug_service_pattern: "*quadlet*"
                 __absent: {"state":"absent"}
                 podman_secrets: "{{ __podman_secrets |
                   map('combine', __absent) | list }}"
@@ -380,9 +381,8 @@
                   - __podman_test_debug_volumes.stdout == ""
                   - __podman_test_debug_containers.stdout == ""
                   - __podman_test_debug_secrets.stdout == ""
-                  - ansible_facts["services"] | dict2items |
-                    rejectattr("value.status", "match", "not-found") |
-                    selectattr("key", "match", "quadlet-demo") |
+                  - __podman_test_debug_services | dict2items |
+                    selectattr("key", "match", "quadlet-basic") |
                     list | length == 0
 
           rescue:

--- a/tests/tests_quadlet_demo.yml
+++ b/tests/tests_quadlet_demo.yml
@@ -168,6 +168,7 @@
               vars:
                 podman_prune_images: true
                 __podman_test_debug: true
+                __podman_test_debug_service_pattern: "*quadlet*"
                 __absent: {"state":"absent"}
                 podman_quadlet_specs: "{{ __podman_quadlet_specs |
                   reverse | map('combine', __absent) | list }}"
@@ -190,8 +191,7 @@
                   - __podman_test_debug_volumes.stdout == ""
                   - __podman_test_debug_containers.stdout == ""
                   - __podman_test_debug_secrets.stdout == ""
-                  - ansible_facts["services"] | dict2items |
-                    rejectattr("value.status", "match", "not-found") |
+                  - __podman_test_debug_services | dict2items |
                     selectattr("key", "match", "quadlet-demo") |
                     list | length == 0
 

--- a/tests/tests_quadlet_pod.yml
+++ b/tests/tests_quadlet_pod.yml
@@ -95,6 +95,7 @@
           vars:
             podman_prune_images: true
             __podman_test_debug: true
+            __podman_test_debug_service_pattern: "*quadlet*"
             podman_run_as_user: user_quadlet_pod
             __absent: {"state":"absent"}
             podman_quadlet_specs: "{{ __podman_quadlet_specs | reverse |
@@ -113,9 +114,8 @@
               - __podman_test_debug_containers.stdout == ""
               - __podman_test_debug_secrets.stdout == ""
               - __podman_test_debug_pods.stdout == ""
-              - ansible_facts["services"] | dict2items |
-                rejectattr("value.status", "match", "not-found") |
-                selectattr("key", "match", "quadlet-demo") |
+              - __podman_test_debug_services | dict2items |
+                selectattr("key", "match", "quadlet-pod") |
                 list | length == 0
 
         - name: Ensure no linger
@@ -178,6 +178,7 @@
               vars:
                 podman_prune_images: true
                 __podman_test_debug: true
+                __podman_test_debug_service_pattern: "*quadlet*"
                 __absent: {"state":"absent"}
                 podman_quadlet_specs: "{{ __podman_quadlet_specs | reverse |
                   map('combine', __absent) | list }}"
@@ -195,9 +196,8 @@
                   - __podman_test_debug_containers.stdout == ""
                   - __podman_test_debug_secrets.stdout == ""
                   - __podman_test_debug_pods.stdout == ""
-                  - ansible_facts["services"] | dict2items |
-                    rejectattr("value.status", "match", "not-found") |
-                    selectattr("key", "match", "quadlet-demo") |
+                  - __podman_test_debug_services | dict2items |
+                    selectattr("key", "match", "quadlet-pod") |
                     list | length == 0
 
           rescue:


### PR DESCRIPTION
The `service_facts` module does not work for user facts, so instead use
`systemctl list-units` looking for quadlet units and format the output
in a test friendly form.

Some of the tests were looking for the wrong services at cleanup, so
fix that too.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Replace rootless service inspection in quadlet cleanup tasks with a test-friendly parser around `systemctl list-units`, and update quadlet tests to consume the new service data and check for the correct unit names.

New Features:
- Expose parsed quadlet service information to tests via a dedicated `__podman_test_debug_services` fact derived from `systemctl list-units` output.

Bug Fixes:
- Fix quadlet tests that were asserting cleanup against the wrong service names by aligning checks with the appropriate quadlet units.

Enhancements:
- Work around `service_facts` limitations for rootless systemd units by using `systemctl list-units` and normalizing its output into a structured dictionary for debugging.

Tests:
- Update quadlet basic, pod, and demo tests to use the new `__podman_test_debug_services` fact instead of `service_facts` and to assert on the correct quadlet unit names.