### PR TITLE
docs(changelog): version 1.11.1 [citest_skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.11.1] - 2026-05-12
+--------------------
+
+### Bug Fixes
+
+- fix: Use verbosity level 3 for no_log (#289)
+
+### Other Changes
+
+- test: use list-units instead of service_facts for user units and fix test checks (#290)
+
 [1.11.0] - 2026-05-07
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.11.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update changelog for the 1.11.1 release.

Bug Fixes:
- Document fix to use verbosity level 3 for no_log handling.

Documentation:
- Add 1.11.1 release notes to the changelog.

Tests:
- Document test changes to use list-units for user units and adjust related checks.