### PR TITLE
fix: enable quadlet services to start at boot

### DIFF
--- a/tasks/create_update_kube_spec.yml
+++ b/tasks/create_update_kube_spec.yml
@@ -80,61 +80,58 @@
   when: __podman_is_booted
   register: __podman_play_info
 
-- name: Reload systemctl  # noqa no-handler
-  systemd:
-    daemon_reload: true
-    scope: "{{ __podman_systemd_scope }}"
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+- name: Handle kube services changes
   when:
-    - __podman_is_booted
     - __podman_play_info is changed or __podman_copy is changed
-    - __podman_activate_systemd_unit | bool
+    - __podman_service_name.stdout | d("") | length > 0
+  block:
+    - name: Reload systemctl  # noqa no-handler
+      systemd:
+        daemon_reload: true
+        scope: "{{ __podman_systemd_scope }}"
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+      when: __podman_is_booted
 
-- name: Enable service  # noqa no-handler
-  systemd:
-    name: "{{ __podman_service_name.stdout }}"
-    scope: "{{ __podman_systemd_scope }}"
-    enabled: true
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-  when:
-    - __podman_play_info is changed or __podman_copy is changed
-    - __podman_activate_systemd_unit | bool
+    - name: Enable service  # noqa no-handler
+      systemd:
+        name: "{{ __podman_service_name.stdout }}"
+        scope: "{{ __podman_systemd_scope }}"
+        enabled: true
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
 
-- name: Start service  # noqa no-handler
-  systemd:
-    name: "{{ __podman_service_name.stdout }}"
-    scope: "{{ __podman_systemd_scope }}"
-    state: started
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-  register: __podman_service_started
-  when:
-    - __podman_is_booted
-    - __podman_play_info is changed or __podman_copy is changed
-    - __podman_activate_systemd_unit | bool
+    - name: Start service  # noqa no-handler
+      systemd:
+        name: "{{ __podman_service_name.stdout }}"
+        scope: "{{ __podman_systemd_scope }}"
+        state: started
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+      register: __podman_service_started
+      when:
+        - __podman_is_booted
+        - __podman_activate_systemd_unit | bool
 
-- name: Restart service  # noqa no-handler
-  systemd:
-    name: "{{ __podman_service_name.stdout }}"
-    scope: "{{ __podman_systemd_scope }}"
-    state: restarted
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-  when:
-    - __podman_is_booted
-    - not __podman_service_started is changed
-    - __podman_play_info is changed or __podman_copy is changed
-    - __podman_activate_systemd_unit | bool
+    - name: Restart service  # noqa no-handler
+      systemd:
+        name: "{{ __podman_service_name.stdout }}"
+        scope: "{{ __podman_systemd_scope }}"
+        state: restarted
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+      when:
+        - __podman_is_booted
+        - not __podman_service_started is changed
+        - __podman_activate_systemd_unit | bool
 
 # auto update not yet working for kube play pods/containers
 # - name: Ensure auto update is running for images

--- a/tasks/create_update_quadlet_spec.yml
+++ b/tasks/create_update_quadlet_spec.yml
@@ -71,68 +71,61 @@
     - __podman_copy_content is skipped
     - __podman_copy_file is skipped
 
-- name: Reload systemctl  # noqa no-handler
-  systemd:
-    daemon_reload: true
-    scope: "{{ __podman_systemd_scope }}"
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-  when:
-    - __podman_is_booted
-    - __podman_copy_content is changed or __podman_copy_file is changed
-      or __podman_template_file is changed
-    - __podman_activate_systemd_unit | bool
+- name: Handle quadlet services changes
+  when: __podman_copy_content is changed or __podman_copy_file is changed
+    or __podman_template_file is changed
+  block:
+    - name: Reload systemctl  # noqa no-handler
+      systemd:
+        daemon_reload: true
+        scope: "{{ __podman_systemd_scope }}"
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+      when: __podman_is_booted
 
-# enablement is not supported for quadlets currently
-# - name: Enable service  # noqa no-handler
-#   systemd:
-#     name: "{{ __podman_service_name }}"
-#     scope: "{{ __podman_systemd_scope }}"
-#     enabled: true
-#   become: "{{ __podman_rootless | ternary(true, omit) }}"
-#   become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-#   environment:
-#     XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-#   when:
-#     - __podman_copy_content is changed or __podman_copy_file is changed
-#       or __podman_template_file is changed
-#     - __podman_service_name | length > 0
-#     - __podman_activate_systemd_unit | bool
+    - name: Enable service  # noqa no-handler
+      systemd:
+        name: "{{ __podman_service_name }}"
+        scope: "{{ __podman_systemd_scope }}"
+        enabled: true
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+      when:
+        - __podman_service_name is not none
+        - __podman_service_name | length > 0
 
-- name: Start service  # noqa no-handler
-  systemd:
-    name: "{{ __podman_service_name }}"
-    scope: "{{ __podman_systemd_scope }}"
-    state: started
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-  register: __podman_service_started
-  when:
-    - __podman_is_booted
-    - __podman_copy_content is changed or __podman_copy_file is changed
-      or __podman_template_file is changed
-    - __podman_service_name is not none
-    - __podman_service_name | length > 0
-    - __podman_activate_systemd_unit | bool
+    - name: Start service  # noqa no-handler
+      systemd:
+        name: "{{ __podman_service_name }}"
+        scope: "{{ __podman_systemd_scope }}"
+        state: started
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+      register: __podman_service_started
+      when:
+        - __podman_is_booted
+        - __podman_service_name is not none
+        - __podman_service_name | length > 0
+        - __podman_activate_systemd_unit | bool
 
-- name: Restart service  # noqa no-handler
-  systemd:
-    name: "{{ __podman_service_name }}"
-    scope: "{{ __podman_systemd_scope }}"
-    state: restarted
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-  when:
-    - __podman_is_booted
-    - not __podman_service_started is changed
-    - __podman_copy_content is changed or __podman_copy_file is changed
-      or __podman_template_file is changed
-    - __podman_service_name is not none
-    - __podman_service_name | length > 0
-    - __podman_activate_systemd_unit | bool
+    - name: Restart service  # noqa no-handler
+      systemd:
+        name: "{{ __podman_service_name }}"
+        scope: "{{ __podman_systemd_scope }}"
+        state: restarted
+      become: "{{ __podman_rootless | ternary(true, omit) }}"
+      become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+      environment:
+        XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+      when:
+        - __podman_is_booted
+        - not __podman_service_started is changed
+        - __podman_service_name is not none
+        - __podman_service_name | length > 0
+        - __podman_activate_systemd_unit | bool

--- a/tests/tests_basic.yml
+++ b/tests/tests_basic.yml
@@ -2,6 +2,8 @@
 ---
 - name: Ensure that the role runs with default parameters
   hosts: all
+  tags:
+    - tests::reboot
   vars_files:
     - vars/test_vars.yml
   vars:
@@ -332,6 +334,46 @@
               command: ls -alrtF {{ __test_tmpdir.path ~ '/' ~ item[0] }}-create
               loop: "{{ test_names_users }}"
               changed_when: false
+
+            - name: Reboot
+              reboot:
+                msg: Rebooting the system to check services are running.
+
+            - name: Check if pods are running after reboot
+              command: podman pod inspect {{ item[0] }} --format {{ __fmt | quote }}
+              changed_when: false
+              register: __output
+              failed_when: __output.stdout != 'Running'
+              become: "{{ (item[1] != 'root') | ternary(true, omit) }}"
+              become_user: "{{ (item[1] != 'root') | ternary(item[1], omit) }}"
+              vars:
+                __fmt: "{{ '{' ~ '{.State}' ~ '}' }}"
+              loop: "{{ test_names_users }}"
+
+            - name: Check Services after reboot
+              shell: |
+                set -euo pipefail
+                systemctl --{{ __state }} list-units -a -l --plain | \
+                  grep -E '{{ __regex }} '
+              changed_when: false
+              become: "{{ (item[1] != 'root') | ternary(true, omit) }}"
+              become_user: "{{ (item[1] != 'root') | ternary(item[1], omit) }}"
+              environment:
+                XDG_RUNTIME_DIR: /run/user/{{ item[2] }}
+              loop: "{{ test_names_users }}"
+              vars:
+                __state: "{{ (item[1] != 'root') | ternary('user', 'system') }}"
+                __regex: >-
+                  ^[  ]*podman-kube@.+-{{ item[0] }}[.]yml[.]service[ ]+loaded[
+                  ]+active
+
+            - name: Check ports, data after reboot
+              uri:
+                url: http://localhost:{{ item }}/index.txt
+                return_content: true
+              register: __return
+              failed_when: __return.content != "123"
+              loop: [15001, 15002]
 
         - name: Run role again to test for idempotency
           include_tasks: tasks/run_role_with_clear_facts.yml

--- a/tests/tests_quadlet_basic.yml
+++ b/tests/tests_quadlet_basic.yml
@@ -2,6 +2,8 @@
 ---
 - name: Ensure that the role can manage quadlet specs
   hosts: all
+  tags:
+    - tests::reboot
   vars_files:
     - vars/test_vars.yml
   vars:
@@ -262,7 +264,40 @@
           register: __result
           failed_when: __result.stdout != __json_secret_data
           changed_when: false
-          when: __podman_is_booted | bool
+
+        - name: Reboot
+          reboot:
+            msg: Rebooting the system to check services are running.
+
+        - name: Check services are running after reboot - user
+          shell:
+            executable: /bin/bash
+            cmd: |
+              set -euxo pipefail
+              exec 1>&2
+              systemctl --user list-units -a -l --plain | grep 'active.*exited.*quadlet-basic-mysql-volume'
+              systemctl --user list-units -a -l --plain | grep 'active.*running.*quadlet-basic-mysql[.]service'
+              systemctl --user list-units -a -l --plain | grep 'active.*exited.*quadlet-basic-network'
+          become: true
+          become_user: user_quadlet_basic
+          environment:
+            XDG_RUNTIME_DIR: /run/user/1111
+          changed_when: false
+
+        - name: Check services are running after reboot - root
+          shell:
+            executable: /bin/bash
+            cmd: |
+              set -euxo pipefail
+              exec 1>&2
+              systemctl --system list-units -a -l --plain | grep 'active.*exited.*quadlet-basic-mysql-volume'
+              systemctl --system list-units -a -l --plain | grep 'active.*running.*quadlet-basic-mysql[.]service'
+              systemctl --system list-units -a -l --plain | grep 'active.*exited.*quadlet-basic-network'
+          become: true
+          become_user: root
+          environment:
+            XDG_RUNTIME_DIR: /run/user/0
+          changed_when: false
 
         # must clean up in the reverse order of creating - and
         # ensure networks are removed last
@@ -293,14 +328,12 @@
               - __podman_test_debug_services | dict2items |
                 selectattr("key", "match", "quadlet-basic") |
                 list | length == 0
-          when: __podman_is_booted | bool
 
         - name: Ensure no linger
           stat:
             path: /var/lib/systemd/linger/user_quadlet_basic
           register: __stat
           failed_when: __stat.stat.exists
-          when: __podman_is_booted | bool
 
       rescue:
         - name: Show error


### PR DESCRIPTION
Cause: quadlet services were not enabled to start at boot.  The code incorrectly
assumed that quadlet services were implicitly enabled.

Consequence: When the system was rebooted, the quadlet services were not running.

Fix: Ensure quadlet services are enabled.

Result: quadlet services are started at boot.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized systemd unit initialization logic for Kubernetes and Quadlet services.
  * Enabled automatic service activation for Quadlet units.

* **Tests**
  * Added reboot scenario validation to verify service persistence and endpoint availability after system restart.
  * Extended test coverage for systemd unit status verification across reboot cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/podman/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->