### PR TITLE
fix: use correct repo name for copr repo

### DIFF
--- a/tasks/enable_copr.yml
+++ b/tasks/enable_copr.yml
@@ -3,7 +3,7 @@
 - name: Enable podman copr on EL
   command: >-
     dnf -y copr enable rhcontainerbot/podman-next
-    centos-stream+epel-next-{{ ansible_facts['distribution_major_version'] }}
+    centos-stream-{{ ansible_facts['distribution_major_version'] }}
   when: ansible_facts['distribution'] in ['RedHat', 'CentOS', 'Alma', 'Rocky']
   changed_when: true
 


### PR DESCRIPTION
the `+epel-next` part of the name is not used anymore

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository configuration for system setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/podman/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->