### PR TITLE
refactor: regex_escape values used with match filter for exact matches

### DIFF
--- a/tasks/create_update_quadlet_spec.yml
+++ b/tasks/create_update_quadlet_spec.yml
@@ -45,7 +45,7 @@
   when:
     - __podman_quadlet_file is not none
     - __podman_quadlet_file | length > 0
-    - __podman_quadlet_file is search('^' ~ __podman_quadlet_path ~ '(/|$)')
+    - __podman_quadlet_file is search('^' ~ (__podman_quadlet_path | regex_escape) ~ '(/|$)')
 
 - name: Ensure quadlet file is copied
   copy:

--- a/tasks/expand_path_restart_entry.yml
+++ b/tasks/expand_path_restart_entry.yml
@@ -13,7 +13,7 @@
   when:
     - item | length > 0
     - __podman_restart_services |
-      selectattr('unit_name', 'match', '^' ~ item ~ '$') | list | length == 0
+      selectattr('unit_name', 'match', '^' ~ (item | regex_escape) ~ '$') | list | length == 0
 
 - name: Expand ALL_SERVICES for dependency path
   set_fact:
@@ -28,7 +28,7 @@
       [__svc | combine({'path': __path_item.path})] }}"
   vars:
     __svc: "{{ __podman_restart_services |
-      selectattr('unit_name', 'match', '^' ~ item ~ '$') | first | default({}) }}"
+      selectattr('unit_name', 'match', '^' ~ (item | regex_escape) ~ '$') | first | default({}) }}"
   loop: "{{ __path_item.restarts | difference(['ALL_SERVICES']) }}"
   when:
     - item | length > 0

--- a/tasks/expand_restarts_on.yml
+++ b/tasks/expand_restarts_on.yml
@@ -7,7 +7,7 @@
 - name: Expand restarts_on for service spec
   vars:
     __restarts_on_service: "{{ __podman_restart_services |
-      selectattr('unit_name', 'match', '^' ~ __podman_spec_name ~ '$') |
+      selectattr('unit_name', 'match', '^' ~ (__podman_spec_name | regex_escape) ~ '$') |
       first | default({}) }}"
   block:
     - name: Expand ANY_DEPENDENCIES paths for restarts_on

--- a/tasks/expand_secret_restart_entry.yml
+++ b/tasks/expand_secret_restart_entry.yml
@@ -14,7 +14,7 @@
     - __secret_restart_item.get('restarts') is not none
     - item | length > 0
     - __podman_restart_services |
-      selectattr('unit_name', 'match', '^' ~ item ~ '$') | list | length == 0
+      selectattr('unit_name', 'match', '^' ~ (item | regex_escape) ~ '$') | list | length == 0
   no_log: "{{ podman_secure_logging }}"
 
 - name: Expand ALL_SERVICES for secret
@@ -33,7 +33,7 @@
       [__svc | combine({'secret': __secret_restart_item.name})] }}"
   vars:
     __svc: "{{ __podman_restart_services |
-      selectattr('unit_name', 'match', '^' ~ item ~ '$') | first | default({}) }}"
+      selectattr('unit_name', 'match', '^' ~ (item | regex_escape) ~ '$') | first | default({}) }}"
   loop: "{{ __secret_restart_item.get('restarts', []) | difference(['ALL_SERVICES']) }}"
   when:
     - __secret_restart_item.get('restarts') is not none

--- a/tasks/handle_user_group.yml
+++ b/tasks/handle_user_group.yml
@@ -100,12 +100,12 @@
           vars:
             __subuid_match_line: "{{
               (__podman_register_subuids.content | b64decode).split('\n') | list |
-              select('match', '^' ~ __podman_handle_user ~ ':') | list }}"
+              select('match', '^' ~ (__podman_handle_user | regex_escape) ~ ':') | list }}"
             __subuid_data: "{{ __subuid_match_line[0].split(':') | list
               if __subuid_match_line else none }}"
             __subgid_match_line: "{{
               (__podman_register_subgids.content | b64decode).split('\n') | list |
-              select('match', '^' ~ __podman_handle_user ~ ':') | list }}"
+              select('match', '^' ~ (__podman_handle_user | regex_escape) ~ ':') | list }}"
             __subgid_data: "{{ __subgid_match_line[0].split(':') | list
               if __subgid_match_line else none }}"
 

--- a/tasks/queue_dependency_restarts.yml
+++ b/tasks/queue_dependency_restarts.yml
@@ -8,7 +8,7 @@
   when: __podman_queue_dependency_restart | bool
   vars:
     __podman_queue_restart_entries: "{{ __podman_path_service_pairs |
-      selectattr('path', 'match', '^' ~ __podman_quadlet_file ~ '$') | list }}"
+      selectattr('path', 'match', '^' ~ (__podman_quadlet_file | regex_escape) ~ '$') | list }}"
   block:
     - name: Append pending service restarts
       set_fact:

--- a/tasks/queue_secret_dependency_restarts.yml
+++ b/tasks/queue_secret_dependency_restarts.yml
@@ -8,7 +8,7 @@
   when: __podman_queue_secret_restart | bool
   vars:
     __podman_queue_restart_entries: "{{ __podman_secret_service_pairs |
-      selectattr('secret', 'match', '^' ~ __podman_secret_item.name ~ '$') | list }}"
+      selectattr('secret', 'match', '^' ~ (__podman_secret_item.name | regex_escape) ~ '$') | list }}"
   no_log: "{{ podman_secure_logging }}"
   block:
     - name: Append pending service restarts


### PR DESCRIPTION
Ensure that values passed to match filters do not have any regex
special characters.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching for service names, user names, paths, secrets, and restart entries containing regex-special characters.
  * Prevented special characters in managed identifiers from causing incorrect filtering or restart behavior.
  * Improved reliability when locating user sub-ID mappings and processing quadlet dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->