### PR TITLE
feat: prune unused images before pulling new ones during create/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,9 +587,16 @@ can override this on a per-spec basis using `validate_certs`.
 
 ### podman_prune_images
 
-Boolean - default is `false` - by default, the role will not prune unused images
-when removing quadlets and other resources.  Set this to `true` to tell the role
-to remove unused images when cleaning up.
+Boolean - default is `false` - set this to `true` to remove unused images.
+The removal runs in two cases:
+
+* **Create/update** - before pulling new images, all unused images are pruned.
+  Because the prune runs while the current container is still running, its image
+  is still in use and will not be pruned, providing a natural rollback to the
+  previous version.
+* **Cleanup** (`state: absent`) - after removing a quadlet or kube spec, only
+  the images that belonged to the removed spec are deleted. Images used by other
+  specs are not affected.
 
 ### podman_transactional_update_reboot_ok
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,8 +136,8 @@ podman_registry_certificates: []
 # You can override this on a per-spec basis using validate_certs
 podman_validate_certs: null
 
-# Prune images when removing quadlets/kube specs -
-# this will remove all unused/unreferenced images
+# Prune unused images - when removing quadlets/kube specs,
+# and before pulling new images during create/update
 podman_prune_images: false
 
 # var to manage reboots for transactional update systems

--- a/tasks/cleanup_kube_spec.yml
+++ b/tasks/cleanup_kube_spec.yml
@@ -90,16 +90,22 @@
     path: "{{ __podman_kube_parsed.kube_file }}"
     state: absent
 
-- name: Prune images no longer in use
-  command: podman image prune -f
+# Prune all unused images after cleanup.  Images from other
+# specs with state != absent are still in use by their running
+# containers and will not be affected.
+- name: Prune unused images
+  command: podman image prune --all -f
+  when:
+    - podman_prune_images | bool
+    - __podman_is_booted
+    - not __podman_kube_parsed.rootless or __podman_xdg_stat.stat.exists
+  register: __podman_prune_result
+  changed_when: __podman_prune_result.stdout | length > 0
+  become: "{{ __podman_kube_parsed.rootless | ternary(true, omit) }}"
+  become_user: "{{ __podman_kube_parsed.rootless |
+    ternary(__podman_kube_parsed.user, omit) }}"
   environment:
     XDG_RUNTIME_DIR: "{{ __podman_kube_parsed.xdg_runtime_dir }}"
-  become: "{{ __podman_kube_parsed.rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_kube_parsed.rootless | ternary(__podman_kube_parsed.user, omit) }}"
-  when:
-    - __podman_is_booted
-    - __podman_removed is changed  # noqa no-handler
-  changed_when: true
 
 - name: Manage linger
   include_tasks: manage_linger.yml

--- a/tasks/cleanup_quadlet_spec.yml
+++ b/tasks/cleanup_quadlet_spec.yml
@@ -154,20 +154,24 @@
         __volume_names: "{{ __config_maps + __secrets + __pvcs }}"
       no_log: "{{ podman_secure_logging }}"
 
-    - name: Clear parsed podman variable
-      set_fact:
-        __podman_quadlet_parsed: null
-
-    - name: Prune images no longer in use
+    # Prune all unused images after cleanup.  Images from other
+    # specs with state != absent are still in use by their running
+    # containers and will not be affected.
+    - name: Prune unused images
       command: podman image prune --all -f
       when:
         - podman_prune_images | bool
         - not __podman_rootless or __podman_xdg_stat.stat.exists
-      changed_when: true
+      register: __podman_prune_result
+      changed_when: __podman_prune_result.stdout | length > 0
       become: "{{ __podman_rootless | ternary(true, omit) }}"
       become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
       environment:
         XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+
+    - name: Clear parsed podman variable
+      set_fact:
+        __podman_quadlet_parsed: null
 
     - name: Manage linger
       include_tasks: manage_linger.yml

--- a/tasks/handle_kube_spec.yml
+++ b/tasks/handle_kube_spec.yml
@@ -32,6 +32,25 @@
     - __podman_kube_parsed.kube_file_field is none or
       __podman_kube_parsed.kube_file_field | length == 0
 
+# podman image prune outputs deleted image IDs to stdout -
+# empty stdout means nothing was pruned.
+# On the create/update path, prune runs before pulling so that
+# the currently running image survives (still in use) and serves
+# as a rollback target.
+- name: Prune unused images before pulling
+  command: podman image prune --all -f
+  when:
+    - podman_prune_images | bool
+    - __podman_is_booted
+    - __podman_kube_parsed.state != "absent"
+  register: __podman_prune_result
+  changed_when: __podman_prune_result.stdout | length > 0
+  become: "{{ __podman_kube_parsed.rootless | ternary(true, omit) }}"
+  become_user: "{{ __podman_kube_parsed.rootless |
+    ternary(__podman_kube_parsed.user, omit) }}"
+  environment:
+    XDG_RUNTIME_DIR: "{{ __podman_kube_parsed.xdg_runtime_dir }}"
+
 - name: Cleanup containers and services
   include_tasks: cleanup_kube_spec.yml
   when: __podman_kube_parsed.state == "absent"

--- a/tasks/handle_quadlet_spec.yml
+++ b/tasks/handle_quadlet_spec.yml
@@ -239,6 +239,24 @@
       else podman_validate_certs }}"
   no_log: "{{ podman_secure_logging }}"
 
+# podman image prune outputs deleted image IDs to stdout -
+# empty stdout means nothing was pruned.
+# On the create/update path, prune runs before pulling so that
+# the currently running image survives (still in use) and serves
+# as a rollback target.
+- name: Prune unused images before pulling
+  command: podman image prune --all -f
+  when:
+    - podman_prune_images | bool
+    - __podman_is_booted
+    - __podman_state != "absent"
+  register: __podman_prune_result
+  changed_when: __podman_prune_result.stdout | length > 0
+  become: "{{ __podman_rootless | ternary(true, omit) }}"
+  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+  environment:
+    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+
 - name: Cleanup quadlets
   include_tasks: cleanup_quadlet_spec.yml
   when: __podman_state == "absent"

--- a/tests/tests_prune_images.yml
+++ b/tests/tests_prune_images.yml
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that podman_prune_images works
+  hosts: all
+  vars_files:
+    - vars/test_vars.yml
+  vars:
+    podman_use_copr: false
+    podman_fail_if_too_old: false
+    __podman_quadlet_specs:
+      - name: prune-test
+        type: container
+        Install:
+          WantedBy: default.target
+        Container:
+          Image: "{{ test_image }}"
+          ContainerName: prune-test-container
+          Exec: /bin/busybox-extras httpd -f -p 80
+  tasks:
+    - name: Test is only supported on x86_64
+      debug:
+        msg: >
+          This test is only supported on x86_64 because the test images
+          used are only available on that platform.
+      when: ansible_facts["architecture"] != "x86_64"
+
+    - name: End test
+      meta: end_play
+      when: ansible_facts["architecture"] != "x86_64"
+
+    - name: Run test
+      block:
+        - name: Run the role to install podman and set internal variables
+          include_tasks: tasks/run_role_with_clear_facts.yml
+
+        - name: Create user for testing
+          user:
+            name: user_prune_images
+            uid: 1222
+          when: not __podman_is_ostree
+
+        - name: Handle linger for user for ostree
+          when: __podman_is_ostree
+          include_role:
+            name: linux-system-roles.podman
+            tasks_from: manage_linger.yml
+          vars:
+            __podman_linger_item_state: present
+            __podman_linger_user: user_prune_images
+            __podman_linger_rootless: true
+
+        - name: Enable EL8 system to support rootless quadlets
+          when:
+            - ansible_facts["os_family"] == "RedHat"
+            - ansible_facts["distribution_version"] is version("9", "<")
+          block:
+            - name: Get local machine ID
+              slurp:
+                path: /etc/machine-id
+              register: __local_mach_id_enc
+              delegate_to: localhost
+
+            - name: Get ansible_facts machine_id
+              setup:
+                gather_subset: machine_id
+
+            - name: Skip test if cannot reboot
+              meta: end_host
+              when: ansible_facts["machine_id"] == __local_mac_id
+              vars:
+                __local_mac_id: "{{ __local_mach_id_enc.content |
+                  b64decode | trim }}"
+
+            - name: Enable cgroup controllers
+              changed_when: true
+              shell: |
+                set -euxo pipefail
+                cat > /etc/systemd/system/user-0.slice <<EOF
+                [Unit]
+                Before=systemd-logind.service
+                [Slice]
+                Slice=user.slice
+                [Install]
+                WantedBy=multi-user.target
+                EOF
+                if [ ! -d /etc/systemd/system/user@.service.d ]; then
+                  mkdir -p /etc/systemd/system/user@.service.d
+                fi
+                cat > /etc/systemd/system/user@.service.d/delegate.conf <<EOF
+                [Service]
+                Delegate=memory pids
+                EOF
+                if [ ! -d /etc/systemd/system/user-.slice.d ]; then
+                  mkdir -p /etc/systemd/system/user-.slice.d
+                fi
+                cat > /etc/systemd/system/user-.slice.d/override.conf <<EOF
+                [Slice]
+                Slice=user.slice
+                CPUAccounting=yes
+                MemoryAccounting=yes
+                IOAccounting=yes
+                TasksAccounting=yes
+                EOF
+                systemctl daemon-reload
+
+            - name: Configure cgroups in kernel
+              command: >-
+                grubby --update-kernel=ALL
+                --args=systemd.unified_cgroup_hierarchy=1
+              changed_when: true
+
+            - name: Reboot
+              reboot:
+
+        - name: Run the role to create quadlet and pull image
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            podman_quadlet_specs: "{{ __podman_quadlet_specs |
+              map('combine', __run_as_user) | list }}"
+            __run_as_user:
+              run_as_user: user_prune_images
+
+        - name: End test when not booted
+          meta: end_host
+          when: not __podman_is_booted | bool
+
+        - name: Pull an extra image to simulate an old unused image
+          containers.podman.podman_image:
+            name: "{{ mysql_image }}"
+            force: true
+          become: true
+          become_user: user_prune_images
+
+        - name: Verify both images are present
+          command: podman images -n --format "{{ '{{' }}.Repository{{ '}}' }}"
+          register: __images_before
+          changed_when: false
+          become: true
+          become_user: user_prune_images
+
+        - name: Assert both images are present
+          assert:
+            that:
+              - __images_before.stdout is search("testimage")
+              - __images_before.stdout is search("mysql")
+
+        - name: Run the role again with podman_prune_images to test
+            prune on update
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            podman_prune_images: true
+            podman_quadlet_specs: "{{ __podman_quadlet_specs |
+              map('combine', __run_as_user) | list }}"
+            __run_as_user:
+              run_as_user: user_prune_images
+
+        - name: Check images after prune on update
+          command: podman images -n --format "{{ '{{' }}.Repository{{ '}}' }}"
+          register: __images_after_update
+          changed_when: false
+          become: true
+          become_user: user_prune_images
+
+        - name: Assert unused image was pruned and running image remains
+          assert:
+            that:
+              - __images_after_update.stdout is search("testimage")
+              - __images_after_update.stdout is not search("mysql")
+
+        - name: Verify container is still running
+          command: podman ps --noheading
+            --format "{{ '{{' }}.Names{{ '}}' }}"
+          register: __containers_running
+          changed_when: false
+          become: true
+          become_user: user_prune_images
+
+        - name: Assert container is running
+          assert:
+            that:
+              - __containers_running.stdout is search("prune-test-container")
+
+        - name: Cleanup with prune on cleanup
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            podman_prune_images: true
+            __podman_test_debug: true
+            __podman_test_debug_service_pattern: "*prune*"
+            podman_run_as_user: user_prune_images
+            __absent:
+                state: absent
+            podman_quadlet_specs: "{{ __podman_quadlet_specs |
+              reverse | map('combine', __absent) | list }}"
+
+        - name: Ensure no resources after cleanup
+          assert:
+            that:
+              - __podman_test_debug_images.stdout == ""
+              - __podman_test_debug_containers.stdout == ""
+              - __podman_test_debug_services | dict2items |
+                selectattr("key", "match", "prune-test") |
+                list | length == 0
+          when: __podman_is_booted | bool
+
+        - name: Ensure no linger
+          stat:
+            path: /var/lib/systemd/linger/user_prune_images
+          register: __stat
+          failed_when: __stat.stat.exists
+          when: __podman_is_booted | bool
+
+      rescue:
+        - name: Show error
+          debug:
+            msg: "{{ ansible_failed_result | to_nice_json }}"
+
+        - name: Debug
+          shell: |
+            set -x
+            set -o pipefail
+            exec 1>&2
+            podman images
+            podman container ls
+            # || true - grep returns 1 when no units match,
+            # which would fail the rescue block
+            systemctl list-units | grep prune || true
+          changed_when: false
+
+        - name: Check AVCs
+          command: grep type=AVC /var/log/audit/audit.log
+          changed_when: false
+          failed_when: false
+
+        - name: Dump journal
+          command: journalctl -ex
+          changed_when: false
+          failed_when: true
+
+      always:
+        - name: End test when not booted
+          meta: end_host
+          when: not __podman_is_booted | d(true) | bool
+
+        - name: Cleanup
+          tags: tests::cleanup
+          block:
+            - name: Cleanup user
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                podman_prune_images: true
+                podman_run_as_user: user_prune_images
+                __absent:
+                  state: absent
+                podman_quadlet_specs: "{{ __podman_quadlet_specs |
+                  reverse | map('combine', __absent) | list }}"
+
+            - name: Remove test user
+              user:
+                name: user_prune_images
+                uid: 1222
+                state: absent


### PR DESCRIPTION
Enhancement: Prune unused images before pulling new ones during create/update

Reason: Users doing continuous container deployments had to remove older image versions in a separate job. The existing `podman_prune_images` variable only pruned images when removing quadlets/kube specs (`state: absent`), not during regular deployments.

Result: When `podman_prune_images` is set to `true`, the role now also runs `podman image prune --all -f` before pulling new images during create/update of quadlets and kube specs. Because the prune runs before the new image pull, the currently running image is still in use and is not pruned, providing a natural rollback to the previous version.

Issue Tracker Tickets (Jira or BZ if any): https://redhat.atlassian.net/browse/RHEL-212676

Fixes #305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced `podman_prune_images` behavior for Quadlet and Kubernetes resources.
  - When enabled, unused images are pruned before pulling new images during create/update, preserving the currently running image for rollback.
  - During resource removal, pruning targets only images associated with the removed spec.
  - Remains disabled by default.

- **Bug Fixes**
  - Refined pruning during cleanup to avoid marking changes when nothing is removed.

- **Tests**
  - Added automated coverage validating prune/cleanup outcomes for Quadlet rootless containers.

- **Documentation**
  - Updated README and inline option docs to clarify the default and prune timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->