### PR TITLE
fix: re-order tasks to allow prune_images to complete on a new host

### DIFF
--- a/tasks/create_update_kube_spec.yml
+++ b/tasks/create_update_kube_spec.yml
@@ -40,6 +40,24 @@
     - podman_create_host_directories | bool
     - __podman_volumes | d([]) | length > 0
 
+# podman image prune outputs deleted image IDs to stdout -
+# empty stdout means nothing was pruned.
+# On the create/update path, prune runs before pulling so that
+# the currently running image survives (still in use) and serves
+# as a rollback target.
+- name: Prune unused images before pulling
+  command: podman image prune --all -f
+  when:
+    - podman_prune_images | bool
+    - __podman_is_booted
+  register: __podman_prune_result
+  changed_when: __podman_prune_result.stdout | length > 0
+  become: "{{ __podman_kube_parsed.rootless | ternary(true, omit) }}"
+  become_user: "{{ __podman_kube_parsed.rootless |
+    ternary(__podman_kube_parsed.user, omit) }}"
+  environment:
+    XDG_RUNTIME_DIR: "{{ __podman_kube_parsed.xdg_runtime_dir }}"
+
 - name: Ensure container images are present
   include_tasks: handle_images.yml
   vars:

--- a/tasks/create_update_quadlet_spec.yml
+++ b/tasks/create_update_quadlet_spec.yml
@@ -22,6 +22,23 @@
     - podman_create_host_directories | bool
     - __podman_volumes | d([]) | length > 0
 
+# podman image prune outputs deleted image IDs to stdout -
+# empty stdout means nothing was pruned.
+# On the create/update path, prune runs before pulling so that
+# the currently running image survives (still in use) and serves
+# as a rollback target.
+- name: Prune unused images before pulling
+  command: podman image prune --all -f
+  when:
+    - podman_prune_images | bool
+    - __podman_is_booted
+  register: __podman_prune_result
+  changed_when: __podman_prune_result.stdout | length > 0
+  become: "{{ __podman_rootless | ternary(true, omit) }}"
+  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
+  environment:
+    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
+
 - name: Ensure container images are present
   include_tasks: handle_images.yml
   vars:

--- a/tasks/handle_kube_spec.yml
+++ b/tasks/handle_kube_spec.yml
@@ -32,25 +32,6 @@
     - __podman_kube_parsed.kube_file_field is none or
       __podman_kube_parsed.kube_file_field | length == 0
 
-# podman image prune outputs deleted image IDs to stdout -
-# empty stdout means nothing was pruned.
-# On the create/update path, prune runs before pulling so that
-# the currently running image survives (still in use) and serves
-# as a rollback target.
-- name: Prune unused images before pulling
-  command: podman image prune --all -f
-  when:
-    - podman_prune_images | bool
-    - __podman_is_booted
-    - __podman_kube_parsed.state != "absent"
-  register: __podman_prune_result
-  changed_when: __podman_prune_result.stdout | length > 0
-  become: "{{ __podman_kube_parsed.rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_kube_parsed.rootless |
-    ternary(__podman_kube_parsed.user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_kube_parsed.xdg_runtime_dir }}"
-
 - name: Cleanup containers and services
   include_tasks: cleanup_kube_spec.yml
   when: __podman_kube_parsed.state == "absent"

--- a/tasks/handle_quadlet_spec.yml
+++ b/tasks/handle_quadlet_spec.yml
@@ -239,24 +239,6 @@
       else podman_validate_certs }}"
   no_log: "{{ podman_secure_logging }}"
 
-# podman image prune outputs deleted image IDs to stdout -
-# empty stdout means nothing was pruned.
-# On the create/update path, prune runs before pulling so that
-# the currently running image survives (still in use) and serves
-# as a rollback target.
-- name: Prune unused images before pulling
-  command: podman image prune --all -f
-  when:
-    - podman_prune_images | bool
-    - __podman_is_booted
-    - __podman_state != "absent"
-  register: __podman_prune_result
-  changed_when: __podman_prune_result.stdout | length > 0
-  become: "{{ __podman_rootless | ternary(true, omit) }}"
-  become_user: "{{ __podman_rootless | ternary(__podman_user, omit) }}"
-  environment:
-    XDG_RUNTIME_DIR: "{{ __podman_xdg_runtime_dir }}"
-
 - name: Cleanup quadlets
   include_tasks: cleanup_quadlet_spec.yml
   when: __podman_state == "absent"

--- a/tests/tests_prune_images.yml
+++ b/tests/tests_prune_images.yml
@@ -115,6 +115,7 @@
         - name: Run the role to create quadlet and pull image
           include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
+            podman_prune_images: true
             podman_quadlet_specs: "{{ __podman_quadlet_specs |
               map('combine', __run_as_user) | list }}"
             __run_as_user:


### PR DESCRIPTION
# Cause
Hello, #312 added the feature of pruning images before pulling them. However, this task is implemented prior to any management of linger. 

# Consequence
If the role is deployed on a genuinely fresh host using rootless podman where `podman_prune_images` is set to `true` the task will fail. See below:

```
TASK [fedora.linux_system_roles.podman : Prune unused images before pulling] **********************************************************************************************************************************
[ERROR]: Task failed: Module failed: The command exited with a non-zero return code.
Origin: /home/build/.ansible/collections/ansible_collections/fedora/linux_system_roles/roles/podman/tasks/handle_quadlet_spec.yml:124:3

122 # the currently running image survives (still in use) and serves
123 # as a rollback target.
124 - name: Prune unused images before pulling
      ^ column 3

fatal: [tokisaki.mapletree.moe]: FAILED! => {"changed": false, "changed_when_result": false, "cmd": ["podman", "image", "prune", "--all", "-f"], "delta": "0:00:00.039726", "end": "2026-08-08 12:59:45.715758", "msg": "The command exited with a non-zero return code.", "rc": 1, "start": "2026-08-08 12:59:45.676032", "stderr": "Failed to obtain podman configuration: lstat /run/user/1000: no such file or directory", "stderr_lines": ["Failed to obtain podman configuration: lstat /run/user/1000: no such file or directory"], "stdout": "", "stdout_lines": []}

```

# Fix
i just re-ordered where the task falls in the chain. the other option to resolve this would be adding an `__podman_xdg_stat.stat.exists` guard to the prune, but re-ordering seemed to me to be a slightly more elegant solution.

additionally, I removed the `absent` clause since it's redundant now, and I added the `podman_prune_images: true` variable to tests so that CI might be able to pick up this issue in the future.

Thank you for all your work on this role, its very useful.

# result
the new task fires after linger has been managed, so it won't hit the XDG Runtime issue.

Signed-off-by: Yuki Matsushita genres.meme4g@icloud.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional cleanup of unused Podman images during system boot before pulling container images.
  * Image cleanup is controlled by the `podman_prune_images` setting.
  * Cleanup supports both Kubernetes-style and Quadlet-managed containers, including rootless operation.

* **Bug Fixes**
  * Prevented image pruning from running during ongoing container handling, limiting cleanup to the boot-time pre-pull process.
  * Improved change reporting so cleanup is only reported when images are actually removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->