### PR TITLE
fix: Relax collection-requirements version constraints

### DIFF
--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,6 +2,5 @@
 ---
 collections:
   - name: ansible.posix
-    version: '>=2.1.0,<2.2.0'
   - name: containers.podman
   - name: fedora.linux_system_roles


### PR DESCRIPTION
Enhancement:
Remove the ansible.posix version constraint from
meta/collection-requirements.yml so modern systems install the latest ansible.posix instead of being held to the 2.1.X series.

Reason:
The '>=2.1.0,<2.2.0' pin existed only to lock ansible.posix to the 2.1.X series for RHEL 7 compatibility (ansible.posix 2.2.0 dropped support for the older Ansible shipped on RHEL 7). The podman role does not support RHEL 7 as a managed node (platforms: EL8, EL9, Fedora; oldest CI ansible-core is 2.16), so the EL7 pin serves no purpose here and only holds the role back to old releases. The role's actual functional minimum is ansible.posix 1.5.0 (rhel_rpm_ostree), which any recent version satisfies.

Result:
ansible.posix is unconstrained again (its pre-EL7-pin state), so systems install the latest release; containers.podman and fedora.linux_system_roles were already unconstrained. No task or module changes are needed because the role never runs on RHEL 7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the version constraint for the `ansible.posix` collection.
  * All other collection requirements remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->