### PR TITLE
fix(quadlet_spec_paths): currently the values are coerced to false an…

### DIFF
--- a/tasks/quadlet_spec_paths.yml
+++ b/tasks/quadlet_spec_paths.yml
@@ -38,10 +38,13 @@
       if 'file_src' in __podman_restart_spec_item else none }}"
     __podman_spec_template_src: "{{ __podman_restart_spec_item['template_src']
       if 'template_src' in __podman_restart_spec_item else none }}"
+    # Jinja returns the last evaluated operand, so using the raw values
+    # produces a string, which `| bool` then evaluates to false meaning the
+    # trigger wouldn't run
     __podman_spec_has_file_data: "{{
       'file_content' in __podman_restart_spec_item or
-      __podman_restart_spec_item.get('file_src') or
-      __podman_restart_spec_item.get('template_src') }}"
+      __podman_restart_spec_item.get('file_src') is truthy or
+      __podman_restart_spec_item.get('template_src') is truthy }}"
   vars:
     __podman_spec_home: "{{
       ansible_facts['getent_passwd'][__podman_spec_user][4] }}"

--- a/tests/files/lsr-dep-index-v1.html
+++ b/tests/files/lsr-dep-index-v1.html
@@ -1,0 +1,1 @@
+<html><body>version1</body></html>

--- a/tests/files/lsr-dep-index-v2.html
+++ b/tests/files/lsr-dep-index-v2.html
@@ -1,0 +1,1 @@
+<html><body>version2</body></html>

--- a/tests/templates/lsr-dep-index.html.j2
+++ b/tests/templates/lsr-dep-index.html.j2
@@ -1,0 +1,1 @@
+<html><body>{{ __dep_template_version }}</body></html>

--- a/tests/tests_dependency_restart.yml
+++ b/tests/tests_dependency_restart.yml
@@ -142,6 +142,122 @@
               - file: "{{ __dep_file }}"
                 state: absent
 
+    - name: Test explicit restarts on template_src dependency file
+      block:
+        - name: Run role - deploy template_src dependency and container
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+            __dep_template_version: version1
+            podman_quadlet_specs:
+              - file: "{{ __dep_file }}"
+                template_src: templates/lsr-dep-index.html.j2
+                restarts: [lsr-dep-http]
+              - "{{ __dep_quadlet_container }}"
+
+        - name: Wait for httpd to serve template_src content
+          uri:
+            url: "http://127.0.0.1:{{ __dep_port }}/"
+            return_content: true
+          register: __dep_http_tmpl_v1
+          until: __dep_http_tmpl_v1.content is search('version1')
+          retries: 15
+          delay: 2
+
+        - name: Run role - update template_src dependency file
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+            __dep_template_version: version2
+            podman_quadlet_specs:
+              - file: "{{ __dep_file }}"
+                template_src: templates/lsr-dep-index.html.j2
+                restarts: [lsr-dep-http]
+              - "{{ __dep_quadlet_container }}"
+
+        - name: Verify container serves updated template_src content
+          uri:
+            url: "http://127.0.0.1:{{ __dep_port }}/"
+            return_content: true
+          register: __dep_http_tmpl_v2
+          until: __dep_http_tmpl_v2.content is search('version2')
+          retries: 15
+          delay: 2
+
+        - name: Assert updated template_src content
+          assert:
+            that: __dep_http_tmpl_v2.content is search('version2')
+
+      always:
+        - name: Cleanup template_src restarts test
+          tags:
+            - tests::cleanup
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            podman_quadlet_specs:
+              - name: lsr-dep-http
+                type: container
+                state: absent
+              - file: "{{ __dep_file }}"
+                state: absent
+
+    - name: Test explicit restarts on file_src dependency file
+      block:
+        - name: Run role - deploy file_src dependency and container
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+            podman_quadlet_specs:
+              - file: "{{ __dep_file }}"
+                file_src: files/lsr-dep-index-v1.html
+                restarts: [lsr-dep-http]
+              - "{{ __dep_quadlet_container }}"
+
+        - name: Wait for httpd to serve file_src content
+          uri:
+            url: "http://127.0.0.1:{{ __dep_port }}/"
+            return_content: true
+          register: __dep_http_fsrc_v1
+          until: __dep_http_fsrc_v1.content is search('version1')
+          retries: 15
+          delay: 2
+
+        - name: Run role - update file_src dependency file
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+            podman_quadlet_specs:
+              - file: "{{ __dep_file }}"
+                file_src: files/lsr-dep-index-v2.html
+                restarts: [lsr-dep-http]
+              - "{{ __dep_quadlet_container }}"
+
+        - name: Verify container serves updated file_src content
+          uri:
+            url: "http://127.0.0.1:{{ __dep_port }}/"
+            return_content: true
+          register: __dep_http_fsrc_v2
+          until: __dep_http_fsrc_v2.content is search('version2')
+          retries: 15
+          delay: 2
+
+        - name: Assert updated file_src content
+          assert:
+            that: __dep_http_fsrc_v2.content is search('version2')
+
+      always:
+        - name: Cleanup file_src restarts test
+          tags:
+            - tests::cleanup
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            podman_quadlet_specs:
+              - name: lsr-dep-http
+                type: container
+                state: absent
+              - file: "{{ __dep_file }}"
+                state: absent
+
     - name: Test explicit restarts on dependency file for kube play
       block:
         - name: Run role - create kube play dependency file


### PR DESCRIPTION
Hello again,

I was attempting to debug why some of my units weren't restarting when their configuration was changed, and ended up digging into the role after I checked everything on my end. A deprecation warning helped me find it!

the current code:
```
    __podman_spec_has_file_data: "{{
      'file_content' in __podman_restart_spec_item or
      __podman_restart_spec_item.get('file_src') or
      __podman_restart_spec_item.get('template_src') }}"
```
results in Jinja forcibly coercing the value to false since it returns a literal string, so the later triggers don't run.

I just added "is truthy" and a note, along with the tests to make sure this is caught in the future. On my mac everything triggers correctly but this will need CI.

Thanks again for this role its super handy!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency-driven restarts now correctly detect changes when content is provided through file or template sources.
  * Services can update and serve newly changed dependency content as expected.
  * Explicit restarts now reliably apply updated dependency content.

* **Tests**
  * Added integration coverage for dependency updates, explicit restarts, cleanup, and refreshed served content.
  * Added fixtures for multiple dependency-index versions and templated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->